### PR TITLE
Fix path handling for configmap/secret volumes

### DIFF
--- a/pkg/server/deploy_util.go
+++ b/pkg/server/deploy_util.go
@@ -105,7 +105,7 @@ func getConfigMapFiles(cmVol *api.ConfigMapVolumeSource, cm *v1.ConfigMap) (map[
 		}
 		archivePath := item.Key
 		if item.Path != "" {
-			archivePath = filepath.Join(item.Path, item.Key)
+			archivePath = item.Path
 		}
 		packageItems[archivePath] = packageFile{
 			data: data,
@@ -157,7 +157,7 @@ func getSecretFiles(secVol *api.SecretVolumeSource, sec *v1.Secret) (map[string]
 		}
 		archivePath := item.Key
 		if item.Path != "" {
-			archivePath = filepath.Join(item.Path, item.Key)
+			archivePath = item.Path
 		}
 		packageItems[archivePath] = packageFile{
 			data: data,

--- a/pkg/server/deploy_util_test.go
+++ b/pkg/server/deploy_util_test.go
@@ -145,7 +145,7 @@ func TestGetConfigMapFiles(t *testing.T) {
 			cm:    simpleConfigMap,
 			isErr: false,
 			expectedFiles: map[string]packageFile{
-				"path/to/bar": packageFile{
+				"path/to": packageFile{
 					data: []byte("barcontent"),
 					mode: allPermsVal,
 				},


### PR DESCRIPTION
The path should be item.Path if it is set, as this is what is expected by pods.