### PR TITLE
changing milpa to kip in all cloud names and tags

### DIFF
--- a/pkg/server/cloud/aws/aws.go
+++ b/pkg/server/cloud/aws/aws.go
@@ -202,7 +202,7 @@ func (m *AwsEC2) GetAttributes() cloud.CloudAttributes {
 }
 
 func filterLabelsForTags(resource string, labels map[string]string) (map[string]string, error) {
-	illegalKeys := []string{"Node", cloud.ControllerTagKey, cloud.ServiceTagKey}
+	illegalKeys := []string{"Node", cloud.ControllerTagKey}
 	ignoredPrefixes := []string{"aws:"}
 	ignoredPrefixes = append(ignoredPrefixes, util.InternalLabelPrefixes...)
 	i := 0

--- a/pkg/server/cloud/aws/network.go
+++ b/pkg/server/cloud/aws/network.go
@@ -19,7 +19,7 @@ import (
 // also watch out for having too many security groups in a VPC
 
 func (e *AwsEC2) CreateSGName(svcName string) string {
-	return util.CreateSecurityGroupName(e.controllerID, "default", svcName)
+	return util.CreateSecurityGroupName(e.controllerID, svcName)
 }
 
 func detectCurrentVPC() (string, error) {

--- a/pkg/server/cloud/aws/security_groups.go
+++ b/pkg/server/cloud/aws/security_groups.go
@@ -48,7 +48,7 @@ func (c *AwsEC2) EnsureMilpaSecurityGroups(extraCIDRs, extraGroupIDs []string) e
 	}
 	vpcCIDRs := []string{c.vpcCIDR}
 	cidrs := append(vpcCIDRs, extraCIDRs...)
-	apiGroupName := util.CreateSecurityGroupName(c.controllerID, "default", cloud.MilpaAPISGName)
+	apiGroupName := util.CreateSecurityGroupName(c.controllerID, cloud.MilpaAPISGName)
 	apiGroup, err := c.EnsureSecurityGroup(apiGroupName, milpaPorts, cidrs)
 	if err != nil {
 		return util.WrapError(err, "Could not setup Milpa API cloud firewall rules")

--- a/pkg/server/cloud/azure/azure.go
+++ b/pkg/server/cloud/azure/azure.go
@@ -162,7 +162,7 @@ func (az *AzureClient) GetAttributes() cloud.CloudAttributes {
 	}
 }
 func filterLabelsForTags(resource string, labels map[string]string) (map[string]*string, error) {
-	illegalKeys := []string{"Node", cloud.ControllerTagKey, cloud.ServiceTagKey}
+	illegalKeys := []string{"Node", cloud.ControllerTagKey}
 	allErrs := []error{}
 	filteredLabels := make(map[string]*string)
 	labelKeys := make([]string, len(labels))

--- a/pkg/server/cloud/azure/security_groups.go
+++ b/pkg/server/cloud/azure/security_groups.go
@@ -170,7 +170,7 @@ func (az *AzureClient) EnsureSecurityGroup(sgName string, ports []cloud.Instance
 }
 
 func (az *AzureClient) CreateSGName(svcName string) string {
-	return util.CreateSecurityGroupName(az.controllerID, "default", svcName)
+	return util.CreateSecurityGroupName(az.controllerID, svcName)
 }
 
 func (az *AzureClient) AttachSecurityGroups(node *api.Node, groups []string) error {

--- a/pkg/server/cloud/cloud.go
+++ b/pkg/server/cloud/cloud.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/klog"
 )
 
-const MilpaAPISGName = "NodeSecurityGroup"
+const MilpaAPISGName = "CellSecurityGroup"
 const PublicCIDR = "0.0.0.0/0"
 const RestAPIPort = 6421
 
@@ -21,12 +21,11 @@ const ProviderAWS = "aws"
 const ProviderGCE = "gce"
 const ProviderAzure = "azure"
 
-const ControllerTagKey = "MilpaControllerID"
+const ControllerTagKey = "KipControllerID"
 const NameTagKey = "Name"
-const NamespaceTagKey = "MilpaNamespace"
-const NametagTagKey = "MilpaNametag"
-const ServiceTagKey = "MilpaServiceName"
-const PodNameTagKey = "MilpaPodName"
+const NamespaceTagKey = "KipNamespace"
+const NametagTagKey = "KipNametag"
+const PodNameTagKey = "KipPodName"
 
 type CloudClient interface {
 	SetBootSecurityGroupIDs([]string)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -189,7 +189,7 @@ func NewInstanceProvider(configFilePath, nodeName, internalIP, serverURL, networ
 	cloudRegion := cloudClient.GetAttributes().Region
 	err = ensureRegionUnchanged(etcdClient, cloudRegion)
 	if err != nil {
-		return nil, fmt.Errorf("error ensuring Milpa region is unchanged: %v", err)
+		return nil, fmt.Errorf("error ensuring Kip region is unchanged: %v", err)
 	}
 	clientCert, err := certFactory.CreateClientCert()
 	if err != nil {

--- a/pkg/util/conmap/README.md
+++ b/pkg/util/conmap/README.md
@@ -7,6 +7,6 @@ To re-generate the gen-conmaps.go with updates from conmaps.go:
 go get github.com/justnoise/genny
 cd $GOPATH/src/github.com/justnoise/genny
 go install
-cd $GOPATH/src/github.com/elotl/milpa/pkg/util/conmap
+cd $GOPATH/src/github.com/elotl/cloud-instance-provider/pkg/util/conmap
 go generate
 ```

--- a/pkg/util/naming.go
+++ b/pkg/util/naming.go
@@ -4,12 +4,9 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"k8s.io/klog"
 )
 
 const (
-	MilpaSvcName       = "milpa"
 	NamespaceSeparator = '_'
 )
 
@@ -53,43 +50,28 @@ func SplitNamespaceAndName(n string) (string, string) {
 	}
 }
 
-func CreateContainerId(podName, unitName string) string {
-	return podName + ".." + unitName
-}
-
-func ContainerIdToPodAndUnitName(containerId string) (string, string) {
-	parts := strings.Split(containerId, "..")
-	if len(parts) != 2 {
-		klog.Errorf("Invalid container ID %s", containerId)
-		return "", ""
-	}
-	podName := parts[0]
-	unitName := parts[1]
-	return podName, unitName
-}
-
 //GCP requires names to follow the regex: [a-z]([-a-z0-9]*[a-z0-9])?
-func CreateSecurityGroupName(controllerID, namespace, svcName string) string {
-	return strings.ToLower(fmt.Sprintf("milpa-%s-%s-%s", controllerID, namespace, svcName))
+func CreateSecurityGroupName(controllerID, svcName string) string {
+	return strings.ToLower(fmt.Sprintf("kip-%s-%s", controllerID, svcName))
 }
 
 func CreateUnboundNodeNameTag(nametag string) string {
 	return fmt.Sprintf(
-		"Milpa Node %s %s", nametag, time.Now().UTC().Format(time.Stamp))
+		"Kip Node %s %s", nametag, time.Now().UTC().Format(time.Stamp))
 }
 
 func CreateBoundNodeNameTag(nametag, podName string) string {
-	return fmt.Sprintf("Milpa Node %s %s", nametag, podName)
+	return fmt.Sprintf("Kip Node %s %s", nametag, podName)
 }
 
 func CreateResourceGroupName(region string) string {
-	return fmt.Sprintf("milpa-%s", region)
+	return fmt.Sprintf("kip-%s", region)
 }
 
 func CreateClusterResourceGroupName(controllerID string) string {
-	return fmt.Sprintf("milpa-%s", controllerID)
+	return fmt.Sprintf("kip-%s", controllerID)
 }
 
 func CreateClusterResourcePrefix(controllerID string) string {
-	return fmt.Sprintf("milpa-%s-", controllerID)
+	return fmt.Sprintf("kip-%s-", controllerID)
 }


### PR DESCRIPTION
I've changed all places kip puts resources in the cloud and calls them "milpa".  I've also simplified security group naming.

Remaining external places with "milpa" in the name:
1. Storage location for all our data in etcd (path is /milpa/blah/blah)
2. Various names and paths in stuff we pass over to itzo
3. tags on our itzo images