### PR TITLE
return errdefs.ErrNotFound in UpdatePod and DeletePod

### DIFF
--- a/pkg/server/registry/pod_registry.go
+++ b/pkg/server/registry/pod_registry.go
@@ -119,6 +119,9 @@ func (reg *PodRegistry) List() (api.MilpaObject, error) {
 func (reg *PodRegistry) Delete(name string) (api.MilpaObject, error) {
 	pod, err := reg.GetPod(name)
 	if err != nil {
+		if err == store.ErrKeyNotFound {
+			return nil, err
+		}
 		msg := fmt.Sprintf("Could not delete pod %s", name)
 		return nil, util.WrapError(err, msg)
 	}
@@ -354,6 +357,9 @@ func (reg *PodRegistry) AtomicUpdate(name string, modifier modifyPodFunc) (*api.
 	for {
 		pair, err := reg.Storer.Get(key)
 		if err != nil {
+			if err == store.ErrKeyNotFound {
+				return nil, err
+			}
 			return nil, fmt.Errorf("Error retrieving pod from storage: %v", err)
 		}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -593,6 +593,10 @@ func (p *InstanceProvider) UpdatePod(ctx context.Context, pod *v1.Pod) error {
 	podRegistry := p.getPodRegistry()
 	_, err = podRegistry.UpdatePodSpecAndLabels(milpaPod)
 	if err != nil {
+		if err == store.ErrKeyNotFound {
+			err = errdefs.NotFoundf("pod %s/%s is not found", pod.Namespace, pod.Name)
+			return err
+		}
 		klog.Errorf("UpdatePod %q: %v", pod.Name, err)
 		return err
 	}
@@ -613,6 +617,10 @@ func (p *InstanceProvider) DeletePod(ctx context.Context, pod *v1.Pod) (err erro
 	podRegistry := p.getPodRegistry()
 	_, err = podRegistry.Delete(milpaPod.Name)
 	if err != nil {
+		if err == store.ErrKeyNotFound {
+			err = errdefs.NotFoundf("pod %s/%s is not found", pod.Namespace, pod.Name)
+			return err
+		}
 		klog.Errorf("DeletePod %q: %v", pod.Name, err)
 		return err
 	}


### PR DESCRIPTION
This should fix issue https://github.com/elotl/cloud-instance-provider/issues/39  We need to signal back to the virtual kubelet that the pod no longer exists in our provider.

While it won't make a difference in VK, in addition to updating `DeletePod` I updated the error type when a pod isn't found in `UpdatePod`.  I think it's good to cover all bases in case things change in VK.