### PR TITLE
Fix pkg/util/version.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ else
 IMAGE_DEV_OR_LATEST=latest
 endif
 
-LD_VERSION_FLAGS=-X main.buildVersion=$(GIT_VERSION) -X main.buildTime=$(CURRENT_TIME)
+LD_VERSION_FLAGS=-X main.buildVersion=$(GIT_VERSION) -X main.buildTime=$(CURRENT_TIME) -X github.com/elotl/cloud-instance-provider/pkg/util.VERSION=$(GIT_VERSION)
 LDFLAGS=-ldflags "$(LD_VERSION_FLAGS)"
 
 BINARIES=virtual-kubelet kipctl

--- a/pkg/util/version_test.go
+++ b/pkg/util/version_test.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/elotl/cloud-instance-provider/pkg/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetVersionInfo(t *testing.T) {
+	testCases := []struct {
+		Version     string
+		VersionInfo api.VersionInfo
+	}{
+		{
+			Version: "v0.0.1-205-g58ce23b-dirty",
+			VersionInfo: api.VersionInfo{
+				Major:        "0",
+				Minor:        "0",
+				GitVersion:   "v0.0.1-205",
+				GitCommit:    "g58ce23b",
+				GitTreeState: "dirty",
+			},
+		},
+		{
+			Version: "v10.33.1-205-g58ce23b-dirty",
+			VersionInfo: api.VersionInfo{
+				Major:        "10",
+				Minor:        "33",
+				GitVersion:   "v10.33.1-205",
+				GitCommit:    "g58ce23b",
+				GitTreeState: "dirty",
+			},
+		},
+		{
+			Version: "v11.22.33-205-g58ce23b",
+			VersionInfo: api.VersionInfo{
+				Major:        "11",
+				Minor:        "22",
+				GitVersion:   "v11.22.33-205",
+				GitCommit:    "g58ce23b",
+				GitTreeState: "clean",
+			},
+		},
+		{
+			Version: "v5.11.8",
+			VersionInfo: api.VersionInfo{
+				Major:        "5",
+				Minor:        "11",
+				GitVersion:   "v5.11.8",
+				GitCommit:    "N/A",
+				GitTreeState: "clean",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		vi := getVersionInfo(tc.Version)
+		assert.Equal(t, tc.VersionInfo, vi)
+	}
+}


### PR DESCRIPTION
We now simply use the version info from "git describe --dirty", instead of assembling the version string ourselves in Makefile. Not sure if "kipctl version" is something we need anymore, but I guess it might still be useful when debugging something, so I updated pkg/util/version.go to ensure VERSION is parsed and api.VersionInfo is filled out correctly.