### PR TITLE
Pin virtual-kubelet/node-cli

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -874,7 +874,7 @@
   version = "v1.5.1"
 
 [[projects]]
-  digest = "1:1c4e09880df2900b30bf9b50cf32568817c3f5ce5ff7015a6cecf513d3a43dbc"
+  digest = "1:e55df715e4af4e0f3fbd2cfb54b22ffef2ab9038e55bc234489ebc7689ae3dab"
   name = "github.com/virtual-kubelet/node-cli"
   packages = [
     ".",
@@ -887,8 +887,7 @@
     "provider",
   ]
   pruneopts = "UT"
-  revision = "cd8af9b9bc8c4cf6e49994bd677165c79d498320"
-  version = "v0.1.2"
+  revision = "1a25cea73ff271b05db8eaf5e901765fefd21c32"
 
 [[projects]]
   digest = "1:ee29cb0ae9cc471817ddfdf0173e8706a8ec227f140c33e30634503917915ced"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -77,6 +77,10 @@
   name = "github.com/elotl/cloud-init"
   branch = "master"
 
+[[constraint]]
+  name = "github.com/virtual-kubelet/node-cli"
+  revision = "1a25cea73ff271b05db8eaf5e901765fefd21c32"
+
 #[[constraint]]
 #  name = "github.com/gogo/protobuf"
 #  version = ">=v1.2.1"

--- a/vendor/github.com/virtual-kubelet/node-cli/internal/commands/root/root.go
+++ b/vendor/github.com/virtual-kubelet/node-cli/internal/commands/root/root.go
@@ -103,13 +103,15 @@ func runRootCommand(ctx context.Context, s *provider.Store, c *opts.Opts) error 
 	configMapInformer := scmInformerFactory.Core().V1().ConfigMaps()
 	serviceInformer := scmInformerFactory.Core().V1().Services()
 
-	go podInformerFactory.Start(ctx.Done())
-	go scmInformerFactory.Start(ctx.Done())
-
 	rm, err := manager.NewResourceManager(podInformer.Lister(), secretInformer.Lister(), configMapInformer.Lister(), serviceInformer.Lister())
 	if err != nil {
 		return errors.Wrap(err, "could not create resource manager")
 	}
+
+	// Start the informers now, so the provider will get a functional resource
+	// manager.
+	podInformerFactory.Start(ctx.Done())
+	scmInformerFactory.Start(ctx.Done())
 
 	apiConfig, err := getAPIConfig(c)
 	if err != nil {


### PR DESCRIPTION
This was my bad, I removed the pin while updating node-cli in the vendor tree. This PR ensures it is pinned to a known good revision.