### PR TITLE
connect to private IPs if cell subnet has no internet gateway

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -21,6 +21,15 @@ annotations:
   pod.elotl.co/launch-type: spot
 ```
 
+** pod.elotl.co/private-ip-only
+
+In AWS, Kip cells will get a public IP address if the cell is run in a subnet connected to an internet gateway.  Set the private-ip-only annotation to "true" instruct kip to run the pod on a cell without a public IP address.  The subnet must be configured to allow downloading the itzo binary and container images without a public IP on the cell.
+
+```yaml
+annotations:
+  pod.elotl.co/private-ip-only: true
+```
+
 **pod.elotl.co/security-groups**
 
 Use the `security-groups` annotation to set one or more security groups on the cloud instance the pod is running on.  If multiple security groups are specified, they should be separated by a comma.  Each cloud instance started by Kip cell has one security group assigned to it by the Kip controller.  In most AWS accounts, instances are limited to 5 security groups.  In those setups, that would leave room for 4 more security groups to be assigned to the cloud instance.

--- a/pkg/api/annotations/pod.go
+++ b/pkg/api/annotations/pod.go
@@ -27,6 +27,12 @@ const PodLaunchType = "pod.elotl.co/launch-type"
 // override specified resource requests and limits.
 const PodInstanceType = "pod.elotl.co/instance-type"
 
+// PodResourcesPrivateIPOnly is an annotation users can put on their
+// kubernetes pods to tell kip to run this pod on a node that only
+// has a private IP address and no public IP address. Setting this
+// value to false will not override the cloud subnet settings.
+const PodResourcesPrivateIPOnly = "pod.elotl.co/private-ip-only"
+
 // PodSecurityGroups is an annotation users can put on their
 // kubernetes pods to tell kip to add additional security groups
 // to the instance backing their pod.

--- a/pkg/server/cloud/aws/network.go
+++ b/pkg/server/cloud/aws/network.go
@@ -284,14 +284,24 @@ func isSubnetPublic(rt []*ec2.RouteTable, subnetID string) (bool, error) {
 	return false, nil
 }
 
+func (e *AwsEC2) ConnectWithPublicIPs() bool {
+	if !e.usePublicIPs {
+		return false
+	} else {
+		return !e.ControllerInsideVPC()
+	}
+}
+
 func (e *AwsEC2) ControllerInsideVPC() bool {
 	vpcID, err := detectCurrentVPC()
-	if err != nil {
-		return false
-	} else if vpcID != "" && vpcID == e.vpcID {
-		return true
+	inside := false
+	if err == nil && vpcID != "" && vpcID == e.vpcID {
+		inside = true
+		klog.V(2).Infoln("controller is inside the VPC")
+	} else {
+		klog.V(2).Infoln("controller is outside the VPC")
 	}
-	return false
+	return inside
 }
 
 func (e *AwsEC2) ModifySourceDestinationCheck(instanceID string, isEnabled bool) error {

--- a/pkg/server/cloud/azure/network.go
+++ b/pkg/server/cloud/azure/network.go
@@ -228,9 +228,9 @@ func (az *AzureClient) getLocalInstanceNetwork() (VirtualNetworkAttributes, clou
 	return vNet, subnet, nil
 }
 
-func (az *AzureClient) ControllerInsideVPC() bool {
+func (az *AzureClient) ConnectWithPublicIPs() bool {
 	_, _, err := az.getLocalInstanceNetwork()
-	return err == nil
+	return err != nil
 }
 
 func (az *AzureClient) ModifySourceDestinationCheck(instanceID string, isEnabled bool) error {

--- a/pkg/server/cloud/cloud.go
+++ b/pkg/server/cloud/cloud.go
@@ -57,7 +57,7 @@ type CloudClient interface {
 	GetImageID(spec BootImageSpec) (string, error)
 	SetSustainedCPU(*api.Node, bool) error
 	AddInstanceTags(string, map[string]string) error
-	ControllerInsideVPC() bool
+	ConnectWithPublicIPs() bool
 	ModifySourceDestinationCheck(string, bool) error
 	RemoveRoute(string) error
 	AddRoute(string, string) error

--- a/pkg/server/cloud/mock.go
+++ b/pkg/server/cloud/mock.go
@@ -133,7 +133,7 @@ func (e *MockCloudClient) CreateSGName(svcName string) string {
 	return fmt.Sprintf("%s.%s.%s", e.ControllerID, "default", svcName)
 }
 
-func (e *MockCloudClient) ControllerInsideVPC() bool {
+func (e *MockCloudClient) ConnectWithPublicIPs() bool {
 	return e.InsideVPC
 }
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -309,11 +309,11 @@ func ConfigureCloud(configFile *ServerConfigFile, controllerID, nametag string) 
 		return nil, fmt.Errorf("Error setting up cloud client: %v", err)
 	}
 
-	usePublicIPs := !cloudClient.ControllerInsideVPC()
-	if usePublicIPs {
-		klog.V(2).Infof("controller is outside the cloud network, connecting via public IPs")
+	connectWithPublicIPs := cloudClient.ConnectWithPublicIPs()
+	if connectWithPublicIPs {
+		klog.V(2).Infof("controller will connect to nodes via public IPs")
 	} else {
-		klog.V(2).Infof("controller is inside the cloud network, connecting via private IPs")
+		klog.V(2).Infof("controller will connect to nodes via private IPs")
 	}
 	err = cloudClient.EnsureMilpaSecurityGroups(
 		configFile.Cells.ExtraCIDRs,

--- a/pkg/server/convert.go
+++ b/pkg/server/convert.go
@@ -18,13 +18,14 @@ package server
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/elotl/kip/pkg/api"
 	"github.com/elotl/kip/pkg/api/annotations"
 	"github.com/elotl/kip/pkg/util"
 	"github.com/elotl/kip/pkg/util/k8s/status"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -612,6 +613,13 @@ func addAnnotationsToMilpaPod(milpaPod *api.Pod) {
 	a = milpaPod.Annotations[annotations.PodInstanceType]
 	if strings.ToLower(a) != "" {
 		milpaPod.Spec.InstanceType = a
+	}
+	a = milpaPod.Annotations[annotations.PodResourcesPrivateIPOnly]
+	if a != "" {
+		val, err := strconv.ParseBool(a)
+		if err == nil {
+			milpaPod.Spec.Resources.PrivateIPOnly = val
+		}
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -49,7 +49,7 @@ import (
 	"github.com/virtual-kubelet/virtual-kubelet/trace"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	restclient "k8s.io/client-go/rest"
@@ -273,9 +273,9 @@ func NewInstanceProvider(configFilePath, nodeName, internalIP, serverURL, networ
 		"Metric": metricsRegistry,
 	}
 
-	usePublicIPs := !cloudClient.ControllerInsideVPC()
+	connectWithPublicIPs := cloudClient.ConnectWithPublicIPs()
 	itzoClientFactory := nodeclient.NewItzoFactory(
-		&certFactory.Root, *clientCert, usePublicIPs)
+		&certFactory.Root, *clientCert, connectWithPublicIPs)
 	nodeDispenser := nodemanager.NewNodeDispenser()
 	podController := &PodController{
 		podRegistry:        podRegistry,


### PR DESCRIPTION
The most noticeable change/rename is moving `ControllerInsideVPC()` out of the `CloudClient` interface. It has been replaced with `ConnectWithPublicIPs()` which is all we were using `ControllerInsideVPC()` for anyways.

At the last minute I also added the `pod.elotl.co/private-ip-only` annotation to allow users to not have a public IP address on their cells. This required re-working the node client to fall back to a private address when a public address isn't available.  It's up to the user to setup VPC endpoints or some other system to download itzo and images (e.g. they could run a private registry and download itzo from an instance located in the subnet).

There's a bit more logging here and there but I think it's for the best, it only shows up when the controller is starting up and that's when you want to see logs.

Tested it all out with a fresh VPC and a poor-man's VPN connection (sshuttle).

To review, a cell only has a private IP when either:
- The subnet does not have a route to an internet gateway
- The user asks for a private address via annotation