### PR TITLE
Update reported k8s version in main.go

### DIFF
--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -35,7 +35,7 @@ import (
 var (
 	buildVersion = "N/A"
 	buildTime    = "N/A"
-	k8sVersion   = "v1.14.0" // This should follow the version of k8s.io/kubernetes we are importing
+	k8sVersion   = "v1.17.0" // This should follow the version of k8s.io/kubernetes we are importing
 )
 
 func main() {


### PR DESCRIPTION
This is a pretty trivial one. At one point we pinned our k8s dependencies to v1.17.0, but did not update k8sversion in main.go then. This should have VK report its version prefix as v1.17.0-vk instead of v1.14.0-vk.