### PR TITLE
Query cloud for DNS info

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -166,6 +166,7 @@ resource "aws_iam_role_policy" "k8s-node" {
         "ec2:DeleteSecurityGroup",
         "ec2:DeleteVolume",
         "ec2:DescribeAddresses",
+        "ec2:DescribeDhcpOptions",
         "ec2:DescribeElasticGpus",
         "ec2:DescribeImages",
         "ec2:DescribeInstances",

--- a/pkg/server/cloud/azure/network.go
+++ b/pkg/server/cloud/azure/network.go
@@ -503,3 +503,7 @@ func getMilpaIPConfiguration(iface network.Interface) (*network.InterfaceIPConfi
 	}
 	return nil, fmt.Errorf("Could not find milpa IP configuration")
 }
+
+func (az *AzureClient) GetDNSInfo() ([]string, []string, error) {
+	return nil, nil, fmt.Errorf("Unimplemented")
+}

--- a/pkg/server/cloud/cloud.go
+++ b/pkg/server/cloud/cloud.go
@@ -62,6 +62,7 @@ type CloudClient interface {
 	RemoveRoute(string) error
 	AddRoute(string, string) error
 	GetVPCCIDRs() []string
+	GetDNSInfo() ([]string, []string, error)
 	// Address spaces used by cloud-internal services that might initiate
 	// connections to instances in the VPC.
 	CloudStatusKeeper() StatusKeeper

--- a/pkg/server/cloud/mock.go
+++ b/pkg/server/cloud/mock.go
@@ -45,6 +45,8 @@ type MockCloudClient struct {
 	InstanceListerFilter func([]string) ([]CloudInstance, error)
 	InstanceLister       func() ([]CloudInstance, error)
 
+	DNSInfoGetter func() ([]string, []string, error)
+
 	RouteRemover func(string) error
 	RouteAdder   func(string, string) error
 
@@ -139,6 +141,10 @@ func (e *MockCloudClient) ConnectWithPublicIPs() bool {
 
 func (e *MockCloudClient) ModifySourceDestinationCheck(iid string, enable bool) error {
 	return nil
+}
+
+func (e *MockCloudClient) GetDNSInfo() ([]string, []string, error) {
+	return e.DNSInfoGetter()
 }
 
 func (e *MockCloudClient) RemoveRoute(destinationCIDR string) error {

--- a/pkg/util/network.go
+++ b/pkg/util/network.go
@@ -40,3 +40,14 @@ func CIDRInsideCIDRs(cidrA string, cidrs []string) bool {
 	}
 	return false
 }
+
+func NextIP(ip net.IP, inc uint) net.IP {
+	i := ip.To4()
+	v := uint(i[0])<<24 + uint(i[1])<<16 + uint(i[2])<<8 + uint(i[3])
+	v += inc
+	v3 := byte(v & 0xFF)
+	v2 := byte((v >> 8) & 0xFF)
+	v1 := byte((v >> 16) & 0xFF)
+	v0 := byte((v >> 24) & 0xFF)
+	return net.IPv4(v0, v1, v2, v3)
+}

--- a/pkg/util/network_test.go
+++ b/pkg/util/network_test.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,5 +55,39 @@ func TestCIDRInsideCIDRs(t *testing.T) {
 		result := CIDRInsideCIDRs(tc.A, tc.B)
 		msg := fmt.Sprintf("testcase %d (zero offset) failed", i)
 		assert.Equal(t, tc.inside, result, msg)
+	}
+}
+
+func TestNextIP(t *testing.T) {
+	testCases := []struct {
+		BaseIP net.IP
+		Inc    uint
+		NextIP net.IP
+	}{
+		{
+			BaseIP: net.ParseIP("10.10.0.0"),
+			Inc:    1,
+			NextIP: net.ParseIP("10.10.0.1"),
+		},
+		{
+			BaseIP: net.ParseIP("10.10.0.255"),
+			Inc:    2,
+			NextIP: net.ParseIP("10.10.1.1"),
+		},
+		{
+			BaseIP: net.ParseIP("192.168.100.255"),
+			Inc:    1,
+			NextIP: net.ParseIP("192.168.101.0"),
+		},
+		{
+			BaseIP: net.ParseIP("255.255.255.255"),
+			Inc:    2,
+			NextIP: net.ParseIP("0.0.0.1"),
+		},
+	}
+	for i, tc := range testCases {
+		nextIP := NextIP(tc.BaseIP, tc.Inc)
+		msg := fmt.Sprintf("testcase %d failed", i+1)
+		assert.Equal(t, tc.NextIP, nextIP, msg)
 	}
 }


### PR DESCRIPTION
Instead of using resolv.conf from the host, query the cloud API on DNS
info such as nameservers and the DNS search list. Kip might be running a
in different network, outside of the pod VPC, with DNS configuration
that might not work inside the VPC.