### PR TITLE
Make pod deletion synchronous

### DIFF
--- a/pkg/server/pod_controller.go
+++ b/pkg/server/pod_controller.go
@@ -151,6 +151,8 @@ func (c *PodController) registerEventHandlers() {
 	c.events.RegisterHandlerFunc(events.PodCreated, c.podCreated)
 	// Useful for kiyot and users updating bare pods
 	c.events.RegisterHandlerFunc(events.PodUpdated, c.podUpdated)
+	// Make deletes synchronous.
+	c.events.RegisterHandlerFunc(events.PodShouldDelete, c.podDeleted)
 }
 
 func (c *PodController) podCreated(e events.Event) error {
@@ -167,6 +169,16 @@ func (c *PodController) podUpdated(e events.Event) error {
 		if err != nil {
 			klog.Errorln("Error updating pod units:", err)
 		}
+	}
+	return nil
+}
+
+func (c *PodController) podDeleted(e events.Event) error {
+	pod := e.Object.(*api.Pod)
+	if pod.Status.BoundNodeName != "" {
+		c.terminateBoundPod(pod)
+	} else {
+		c.terminateUnboundPod(pod)
 	}
 	return nil
 }

--- a/pkg/server/registry/common.go
+++ b/pkg/server/registry/common.go
@@ -16,7 +16,23 @@ limitations under the License.
 
 package registry
 
-import "github.com/elotl/kip/pkg/api"
+import (
+	"fmt"
+
+	"github.com/elotl/kip/pkg/api"
+)
+
+func checkObjectMetaForUpdate(dest *api.ObjectMeta, src *api.ObjectMeta) error {
+	if !src.CreationTimestamp.IsZero() && !src.CreationTimestamp.Equal(dest.CreationTimestamp) {
+		return fmt.Errorf("CreationTimestamp is an immutable field %v != %v",
+			src.CreationTimestamp, dest.CreationTimestamp)
+	}
+	if src.UID != "" && src.UID != dest.UID {
+		return fmt.Errorf("UID is an immutable field %v != %v",
+			src.UID, dest.UID)
+	}
+	return nil
+}
 
 func copyObjectMetaForUpdate(dest *api.ObjectMeta, src *api.ObjectMeta) {
 	dest.Labels = src.Labels

--- a/pkg/server/registry/pod_registry.go
+++ b/pkg/server/registry/pod_registry.go
@@ -212,6 +212,13 @@ func (reg *PodRegistry) UpdatePodSpecAndLabels(p *api.Pod) (*api.Pod, error) {
 		return nil, err
 	}
 	p, err = reg.AtomicUpdate(p.Name, func(in *api.Pod) error {
+		if api.IsTerminalPodPhase(in.Spec.Phase) {
+			return fmt.Errorf("pod spec is in a terminal phase")
+		}
+		err = checkObjectMetaForUpdate(&in.ObjectMeta, &p.ObjectMeta)
+		if err != nil {
+			return err
+		}
 		copyObjectMetaForUpdate(&in.ObjectMeta, &p.ObjectMeta)
 		in.Spec = p.Spec
 		return nil


### PR DESCRIPTION
This makes sure we don't keep pods in our registry after the user deletes them, thus they can be recreated right away in the same namespace with the same name.

I also added some extra checks to pod updates in the registry.