### PR TITLE
Add annotation for creating pod cloud routes

### DIFF
--- a/cmd/virtual-kubelet/flags.go
+++ b/cmd/virtual-kubelet/flags.go
@@ -28,6 +28,6 @@ func (c *ServerConfig) FlagSet() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("serverconfig", pflag.ContinueOnError)
 	flags.BoolVar(&c.DebugServer, "debug-server", c.DebugServer, "Enable a listener in the server for inspecting internal kip structures.")
 	flags.StringVar(&c.NetworkAgentSecret, "network-agent-secret", c.NetworkAgentSecret, "Service account secret for the cell network agent, in the form of <namespace>/<name>")
-	flags.StringVar(&c.ClusterDNS, "cluster-dns", c.ClusterDNS, "Default cluster DNS server to use")
+	flags.StringVar(&c.ClusterDNS, "cluster-dns", c.ClusterDNS, "Default cluster DNS server to use; if not specified, the kube-system/kube-dns service IP will be used")
 	return flags
 }

--- a/cmd/virtual-kubelet/flags.go
+++ b/cmd/virtual-kubelet/flags.go
@@ -21,11 +21,13 @@ import "github.com/spf13/pflag"
 type ServerConfig struct {
 	DebugServer        bool
 	NetworkAgentSecret string
+	ClusterDNS         string
 }
 
 func (c *ServerConfig) FlagSet() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("serverconfig", pflag.ContinueOnError)
 	flags.BoolVar(&c.DebugServer, "debug-server", c.DebugServer, "Enable a listener in the server for inspecting internal kip structures.")
 	flags.StringVar(&c.NetworkAgentSecret, "network-agent-secret", c.NetworkAgentSecret, "Service account secret for the cell network agent, in the form of <namespace>/<name>")
+	flags.StringVar(&c.ClusterDNS, "cluster-dns", c.ClusterDNS, "Default cluster DNS server to use")
 	return flags
 }

--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -87,6 +87,8 @@ func main() {
 					internalIP,
 					serverURL,
 					serverConfig.NetworkAgentSecret,
+					serverConfig.ClusterDNS,
+					cfg.KubeClusterDomain,
 					cfg.DaemonPort,
 					serverConfig.DebugServer,
 					cfg.ResourceManager,

--- a/deploy/terraform-vpn/kustomization/deployment.yaml.tmpl
+++ b/deploy/terraform-vpn/kustomization/deployment.yaml.tmpl
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: virtual-kubelet
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - /virtual-kubelet
+        - --provider
+        - kip
+        - --provider-config
+        - /etc/virtual-kubelet/provider.yaml
+        - --network-agent-secret
+        - kube-system/vk-network-agent
+        - --disable-taint
+        - --cluster-dns=${local_dns}
+        - --klog.logtostderr
+        - --klog.v=2
+        name: virtual-kubelet

--- a/deploy/terraform-vpn/kustomization/kustomization.yaml.tmpl
+++ b/deploy/terraform-vpn/kustomization/kustomization.yaml.tmpl
@@ -2,6 +2,9 @@ bases:
 - ../../manifests/virtual-kubelet/overlays/minikube/
 resources:
 - vpn-deployment.yaml
+- node-local-dns.yaml
+patchesStrategicMerge:
+- deployment.yaml
 configMapGenerator:
 - name: virtual-kubelet-config
   namespace: kube-system

--- a/deploy/terraform-vpn/kustomization/node-local-dns.yaml.tmpl
+++ b/deploy/terraform-vpn/kustomization/node-local-dns.yaml.tmpl
@@ -1,0 +1,198 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns-upstream
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "KubeDNSUpstream"
+spec:
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+    targetPort: 53
+  selector:
+    k8s-app: kube-dns
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  Corefile: |
+    ${cluster_domain}:53 {
+        errors
+        cache {
+                success 9984 30
+                denial 9984 5
+        }
+        reload
+        loop
+        bind ${local_dns} 
+        forward . ${kube_dns} {
+                force_tcp
+        }
+        prometheus :9253
+        health ${local_dns}:8080
+        }
+    in-addr.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind ${local_dns} 
+        forward . ${kube_dns} {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    ip6.arpa:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind ${local_dns} 
+        forward . ${kube_dns} {
+                force_tcp
+        }
+        prometheus :9253
+        }
+    .:53 {
+        errors
+        cache 30
+        reload
+        loop
+        bind ${local_dns} 
+        forward . 8.8.8.8 8.8.4.4 1.1.1.1
+        prometheus :9253
+        }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-local-dns
+  namespace: kube-system
+  labels:
+    k8s-app: node-local-dns
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+  selector:
+    matchLabels:
+      k8s-app: node-local-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: node-local-dns
+      annotations:
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
+        pod.elotl.co/cloud-route: "${local_dns}/32"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "kubernetes.io/hostname"
+                operator: In
+                values:
+                - virtual-kubelet
+      priorityClassName: system-node-critical
+      serviceAccountName: node-local-dns
+      hostNetwork: true
+      dnsPolicy: Default  # Don't use cluster DNS.
+      tolerations:
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      - effect: "NoExecute"
+        operator: "Exists"
+      - effect: "NoSchedule"
+        operator: "Exists"
+      containers:
+      - name: node-cache
+        image: k8s.gcr.io/k8s-dns-node-cache:1.15.10
+        resources:
+          requests:
+            cpu: 25m
+            memory: 5Mi
+        args: [ "-localip", "${local_dns}", "-conf", "/etc/Corefile", "-upstreamsvc", "kube-dns-upstream" ]
+        securityContext:
+          privileged: true
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9253
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            host: ${local_dns}
+            path: /health
+            port: 8080
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+        volumeMounts:
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+          readOnly: false
+        - name: config-volume
+          mountPath: /etc/coredns
+        - name: kube-dns-config
+          mountPath: /etc/kube-dns
+      volumes:
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+      - name: kube-dns-config
+        configMap:
+          name: kube-dns
+          optional: true
+      - name: config-volume
+        configMap:
+          name: node-local-dns
+          items:
+            - key: Corefile
+              path: Corefile.base

--- a/deploy/terraform-vpn/variables.tf
+++ b/deploy/terraform-vpn/variables.tf
@@ -119,3 +119,21 @@ variable "vpn_hostnetwork" {
   default     = true
   description = "Whether to run the VPN client pod in host network mode, thus directly adding routes on the worker node host (useful for a simple static route setup). If you plan on using BGP with the VPN tunnel, set it to false, and instead add the VPN client pod as a BGP peer."
 }
+
+variable "cluster_domain" {
+  type = string
+  default = "cluster.local"
+  description = "The Kubernetes cluster domain, used by pods. See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/ for more information."
+}
+
+variable "kube_dns" {
+  type = string
+  default = "10.96.0.10"
+  description = "The clusterIP of the main DNS service (usually called kube-dns) in Kubernetes. See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/ for more information."
+}
+
+variable "local_dns" {
+  type = string
+  default = "169.254.10.20"
+  description = "The IP address used for the local DNS cache pod that will be launched in the VPC to improve DNS performance. See https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/ on DNS caching."
+}

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -47,3 +47,12 @@ AWS Instance profiles can be attached to the instances backing Kip cells.  At th
 annotations:
   pod.elotl.co/instance-profile: "arn:aws:iam::11123456789:instance-profile/kip-s3-full-access-role"
 ```
+
+**pod.elotl.co/cloud-route**
+
+This annotation can be used to add one or more routes to the cloud subnet route table.  The value must be one or more CIDRs separated by whitespace, e.g. "10.20.30.40/24 192.168.1.0/28". Route to these CIDRs, using the instance as the next hop, will be added to the route table of the subnet.
+
+```yaml
+annotations:
+  pod.elotl.co/cloud-route: "10.20.30.40/24 192.168.1.0/28"
+```

--- a/pkg/api/annotations/pod.go
+++ b/pkg/api/annotations/pod.go
@@ -52,3 +52,9 @@ const PodTaskExecutionRole = "pod.elotl.co/task-execution-role"
 // that containers in a fargate task can assume. All containers
 // in the task assume this role.
 const PodTaskRole = "pod.elotl.co/task-role"
+
+// PodCloudRoute can be used to add one or more routes to the cloud subnet
+// route table.  The value must be one or more CIDRs separated by whitespace,
+// e.g. "10.20.30.40/24 192.168.1.0/28". Route to these CIDRs, using the
+// instance as the next hop, will be added to the route table of the subnet.
+const PodCloudRoute = "pod.elotl.co/cloud-route"

--- a/pkg/server/cloud/azure/network.go
+++ b/pkg/server/cloud/azure/network.go
@@ -265,10 +265,27 @@ func (az *AzureClient) ModifySourceDestinationCheck(instanceID string, isEnabled
 	return nil
 }
 
-func (az *AzureClient) RemoveRoute(destinationCIDR string) error {
+func (az *AzureClient) RemoveRoute(destinationCIDR, instanceID string) error {
+	if destinationCIDR == "" || instanceID == "" {
+		return fmt.Errorf(
+			"invalid input: at least one non-empty value needed (got %q %q)",
+			destinationCIDR, instanceID)
+	}
 	ctx := context.Background()
 	timeoutCtx, cancel := context.WithTimeout(ctx, azureDefaultTimeout)
 	defer cancel()
+	ipAddress := ""
+	if instanceID != "" {
+		nic, err := az.nics.Get(timeoutCtx, instanceID, instanceID, "")
+		if err != nil {
+			return util.WrapError(err, "looking up NIC for adding route")
+		}
+		ipconfig, err := getMilpaIPConfiguration(nic)
+		if err != nil {
+			return util.WrapError(err, "getting IP config for adding route")
+		}
+		ipAddress = to.String(ipconfig.PrivateIPAddress)
+	}
 	vnet, err := az.vnets.Get(
 		timeoutCtx, az.virtualNetwork.ResourceGroup, az.virtualNetwork.Name, "")
 	if err != nil {
@@ -300,8 +317,16 @@ func (az *AzureClient) RemoveRoute(destinationCIDR string) error {
 			if route.RoutePropertiesFormat == nil {
 				continue
 			}
+			if route.RoutePropertiesFormat.NextHopType !=
+				network.RouteNextHopTypeVnetLocal {
+				continue
+			}
 			cidr := to.String(route.RoutePropertiesFormat.AddressPrefix)
-			if cidr != destinationCIDR {
+			if destinationCIDR != "" && cidr != destinationCIDR {
+				continue
+			}
+			nextHop := to.String(route.RoutePropertiesFormat.NextHopIPAddress)
+			if ipAddress != "" && nextHop != ipAddress {
 				continue
 			}
 			details, err = azure.ParseResourceID(to.String(route.ID))
@@ -336,6 +361,11 @@ func (az *AzureClient) RemoveRoute(destinationCIDR string) error {
 }
 
 func (az *AzureClient) AddRoute(destinationCIDR, instanceID string) error {
+	if destinationCIDR == "" && instanceID == "" {
+		return fmt.Errorf(
+			"invalid input: empty value (got %q %q)",
+			destinationCIDR, instanceID)
+	}
 	ctx := context.Background()
 	timeoutCtx, cancel := context.WithTimeout(ctx, azureDefaultTimeout)
 	defer cancel()

--- a/pkg/server/cloud/azure/network.go
+++ b/pkg/server/cloud/azure/network.go
@@ -266,7 +266,10 @@ func (az *AzureClient) ModifySourceDestinationCheck(instanceID string, isEnabled
 }
 
 func (az *AzureClient) RemoveRoute(destinationCIDR, instanceID string) error {
-	if destinationCIDR == "" || instanceID == "" {
+	if destinationCIDR == "" && instanceID == "" {
+		// TODO: Azure does not provide route state like AWS does, so we don't
+		// know if an instance route is dangling. We need to check if the next
+		// hop IP is in use, or has gone away.
 		return fmt.Errorf(
 			"invalid input: at least one non-empty value needed (got %q %q)",
 			destinationCIDR, instanceID)
@@ -361,7 +364,7 @@ func (az *AzureClient) RemoveRoute(destinationCIDR, instanceID string) error {
 }
 
 func (az *AzureClient) AddRoute(destinationCIDR, instanceID string) error {
-	if destinationCIDR == "" && instanceID == "" {
+	if destinationCIDR == "" || instanceID == "" {
 		return fmt.Errorf(
 			"invalid input: empty value (got %q %q)",
 			destinationCIDR, instanceID)

--- a/pkg/server/cloud/cloud.go
+++ b/pkg/server/cloud/cloud.go
@@ -59,7 +59,7 @@ type CloudClient interface {
 	AddInstanceTags(string, map[string]string) error
 	ConnectWithPublicIPs() bool
 	ModifySourceDestinationCheck(string, bool) error
-	RemoveRoute(string) error
+	RemoveRoute(string, string) error
 	AddRoute(string, string) error
 	GetVPCCIDRs() []string
 	GetDNSInfo() ([]string, []string, error)

--- a/pkg/server/cloud/mock.go
+++ b/pkg/server/cloud/mock.go
@@ -47,7 +47,7 @@ type MockCloudClient struct {
 
 	DNSInfoGetter func() ([]string, []string, error)
 
-	RouteRemover func(string) error
+	RouteRemover func(string, string) error
 	RouteAdder   func(string, string) error
 
 	StatusKeeperGetter func() StatusKeeper
@@ -153,8 +153,8 @@ func (e *MockCloudClient) GetDNSInfo() ([]string, []string, error) {
 	return e.DNSInfoGetter()
 }
 
-func (e *MockCloudClient) RemoveRoute(destinationCIDR string) error {
-	return e.RouteRemover(destinationCIDR)
+func (e *MockCloudClient) RemoveRoute(destinationCIDR, nextHop string) error {
+	return e.RouteRemover(destinationCIDR, nextHop)
 }
 
 func (e *MockCloudClient) AddRoute(destinationCIDR, instanceID string) error {
@@ -304,11 +304,11 @@ func NewMockClient() *MockCloudClient {
 		return p, nil
 	}
 
-	net.RouteRemover = func(destinationCIDR string) error {
+	net.RouteRemover = func(destinationCIDR, nextHop string) error {
 		return nil
 	}
 
-	net.RouteAdder = func(destinationCIDR, instanceID string) error {
+	net.RouteAdder = func(destinationCIDR, nextHop string) error {
 		return nil
 	}
 

--- a/pkg/server/deploy_util.go
+++ b/pkg/server/deploy_util.go
@@ -30,7 +30,7 @@ import (
 	"github.com/elotl/kip/pkg/util"
 	"github.com/kubernetes/kubernetes/pkg/kubelet/network/dns"
 	"github.com/virtual-kubelet/node-cli/manager"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"

--- a/pkg/server/garbage_controller.go
+++ b/pkg/server/garbage_controller.go
@@ -90,6 +90,7 @@ func (c *GarbageController) GCLoop(quit <-chan struct{}, wg *sync.WaitGroup) {
 		case <-instancesTicker.C:
 			c.timer.StartLoop()
 			c.CleanInstances()
+			c.CleanDanglingRoutes()
 			c.timer.EndLoop()
 		case <-cleanTermiantedTicker.C:
 			c.CleanTerminatedNodes()
@@ -99,6 +100,13 @@ func (c *GarbageController) GCLoop(quit <-chan struct{}, wg *sync.WaitGroup) {
 			klog.V(2).Info("Stopping GarbageController")
 			return
 		}
+	}
+}
+
+func (c *GarbageController) CleanDanglingRoutes() {
+	err := c.cloudClient.RemoveRoute("", "")
+	if err != nil {
+		klog.Warningf("cleaning up dangling routes: %v", err)
 	}
 }
 

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -1,0 +1,87 @@
+package server
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"strings"
+
+	"github.com/elotl/kip/pkg/server/cloud"
+	"github.com/elotl/kip/pkg/util"
+	"github.com/elotl/kip/pkg/util/k8s"
+	"github.com/elotl/kip/pkg/util/k8s/eventrecorder"
+	"github.com/kubernetes/kubernetes/pkg/kubelet/network/dns"
+	"github.com/virtual-kubelet/node-cli/manager"
+	v1 "k8s.io/api/core/v1"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/klog"
+)
+
+func createResolverFile(nameservers, searches []string) (string, error) {
+	tmpf, err := ioutil.TempFile("", "resolv-conf")
+	if err != nil {
+		klog.Warningf("creating resolver tempfile: %v", err)
+		return "", err
+	}
+	defer tmpf.Close()
+	for _, ns := range nameservers {
+		tmpf.Write([]byte(fmt.Sprintf("nameserver %s\n", ns)))
+	}
+	if len(searches) > 0 {
+		searchList := strings.Join(searches, " ")
+		tmpf.Write([]byte(fmt.Sprintf("search %s\n", searchList)))
+	}
+	resolverConfig := tmpf.Name()
+	return resolverConfig, nil
+}
+
+func createDNSConfigurer(kubernetesNodeName, clusterDNS, clusterDomain string, cloudClient cloud.CloudClient, rm *manager.ResourceManager) (*dns.Configurer, error) {
+	loggingEventRecorder := eventrecorder.NewLoggingEventRecorder(4)
+	nodeRef := &v1.ObjectReference{
+		Kind:       "Node",
+		APIVersion: "v1",
+		Name:       kubernetesNodeName,
+	}
+	nameservers, searches, err := cloudClient.GetDNSInfo()
+	if err != nil {
+		return nil, util.WrapError(err, "getting cloud DNS info")
+	}
+	klog.V(2).Infof("host nameservers %v searches %v", nameservers, searches)
+	resolverConfig, err := createResolverFile(nameservers, searches)
+	ip := net.ParseIP(clusterDNS)
+	if ip == nil || ip.IsUnspecified() {
+		services, err := rm.ListServices()
+		if err != nil {
+			return nil, util.WrapError(err, "looking up kube-dns service")
+		}
+		for _, svc := range services {
+			if svc.Name != "kube-dns" || svc.Namespace != "kube-system" {
+				continue
+			}
+			ip = net.ParseIP(svc.Spec.ClusterIP)
+		}
+	}
+	if ip == nil || ip.IsUnspecified() {
+		return nil, fmt.Errorf("missing or misconfigured kube-dns service")
+	}
+	return dns.NewConfigurer(
+		loggingEventRecorder,
+		nodeRef,
+		nil,
+		[]net.IP{ip},
+		clusterDomain,
+		resolverConfig,
+	), nil
+}
+
+func createNetworkAgentKubeconfig(kubernetesNodeName, networkAgentSecret, serverURL string, rm *manager.ResourceManager) (*clientcmdapi.Config, error) {
+	kc, err := k8s.CreateNetworkAgentKubeconfig(
+		rm, serverURL, networkAgentSecret)
+	if err != nil {
+		return nil, util.WrapError(err, "creating network-agent kubeconfig")
+	}
+	if err := k8s.ValidateKubeconfig(kc); err != nil {
+		return nil, util.WrapError(err, "validating network-agent kubeconfig")
+	}
+	return kc, err
+}

--- a/pkg/server/nodemanager/node_controller.go
+++ b/pkg/server/nodemanager/node_controller.go
@@ -330,6 +330,7 @@ func (c *NodeController) stopSingleNode(node *api.Node) error {
 	}
 	c.NodeClientFactory.DeleteClient(node.Status.Addresses)
 	go func(n *api.Node) {
+		_ = c.CloudClient.RemoveRoute("", n.Status.InstanceID)
 		_ = c.CloudClient.StopInstance(n.Status.InstanceID)
 		_, err := c.NodeRegistry.PurgeNode(node)
 		if err != nil {

--- a/pkg/server/nodemanager/node_controller.go
+++ b/pkg/server/nodemanager/node_controller.go
@@ -330,7 +330,6 @@ func (c *NodeController) stopSingleNode(node *api.Node) error {
 	}
 	c.NodeClientFactory.DeleteClient(node.Status.Addresses)
 	go func(n *api.Node) {
-		_ = c.CloudClient.RemoveRoute("", n.Status.InstanceID)
 		_ = c.CloudClient.StopInstance(n.Status.InstanceID)
 		_, err := c.NodeRegistry.PurgeNode(node)
 		if err != nil {

--- a/pkg/server/nodemanager/node_controller_test.go
+++ b/pkg/server/nodemanager/node_controller_test.go
@@ -47,6 +47,10 @@ var (
 
 type StartStopFunc func(node *api.Node) error
 
+func StringStringReturnNil(cidr, iid string) error {
+	return nil
+}
+
 func ReturnNil(iid string) error {
 	return nil
 }
@@ -84,10 +88,11 @@ func MakeNodeController() (*NodeController, func()) {
 	podRegistry, closer3 := registry.SetupTestPodRegistry()
 	closer := func() { closer1(); closer2(); closer3() }
 	cloudClient := &cloud.MockCloudClient{
-		Starter:     StartReturnsOK,
-		SpotStarter: StartReturnsOK,
-		Stopper:     ReturnNil,
-		Waiter:      ReturnAddresses,
+		Starter:      StartReturnsOK,
+		SpotStarter:  StartReturnsOK,
+		Stopper:      ReturnNil,
+		Waiter:       ReturnAddresses,
+		RouteRemover: StringStringReturnNil,
 	}
 	imageIdCache := timeoutmap.New(false, make(chan struct{}))
 	imageIdCache.Add(defaultBootImageSpec.String(), defaultBootImageID, 5*time.Minute, timeoutmap.Noop)
@@ -608,10 +613,11 @@ func TestDoPoolsCalculation(t *testing.T) {
 	ctl, closer := MakeNodeController()
 	defer closer()
 	ctl.CloudClient = &cloud.MockCloudClient{
-		Starter:     StartReturnsOK,
-		SpotStarter: StartReturnsOK,
-		Stopper:     ReturnNil,
-		Waiter:      ReturnAddresses,
+		Starter:      StartReturnsOK,
+		SpotStarter:  StartReturnsOK,
+		Stopper:      ReturnNil,
+		Waiter:       ReturnAddresses,
+		RouteRemover: StringStringReturnNil,
 		ImageIDGetter: func(spec cloud.BootImageSpec) (string, error) {
 			return "", nil
 		},

--- a/pkg/server/pod_controller.go
+++ b/pkg/server/pod_controller.go
@@ -1093,20 +1093,7 @@ func (c *PodController) ControlPods() {
 }
 
 func (c *PodController) createDNSConfigurer() {
-	// TODO: get rid of this retry loop once VK is fixed.
-	err := util.Retry(
-		// Timeout.
-		15*time.Second,
-		func() error {
-			err := c.doCreateDNSConfigurer()
-			return err
-		},
-		func(err error) bool {
-			// Always retry.
-			return true
-		},
-	)
-	if err != nil {
+	if err := c.doCreateDNSConfigurer(); err != nil {
 		klog.Fatalf("creating DNS configurer: %v", err)
 	}
 }


### PR DESCRIPTION
Changes:
- New `pod.elotl.co/cloud-route: <cidr1 cidr2 ...>` annotation, that will make Kip add a route in the cloud subnet route table, using the instance backing the pod as the next hop for the CIDRs.
- I refactored the setup for DNS and how the network agent token is created, to reduce clutter in the pod controller, and injecting them as PodController dependencies.
- I threaded through the `--cluster-domain` parameter from node-cli, so the cluster domain can now be overridden.
- Added a `--cluster-dns` parameter to make the DNS used by pods with a `ClusterFirst` DNS policy configurable.

The main use case right now is to allow a caching DNS server in the VPC subnet for a hybrid on-prem/cloud setup: the caching DNS pod can add a route to its extra IP address (e.g. node-local-dns has a link-local listener by default), and the operator can also inject this IP via the `--cluster-dns <same link-local address>` parameter to Kip.