### PR TITLE
fix up pod phase: reset to Pending when kip pod should be restarted

### DIFF
--- a/pkg/server/convert.go
+++ b/pkg/server/convert.go
@@ -72,7 +72,14 @@ func getStatus(internalIP string, milpaPod *api.Pod, pod *v1.Pod) v1.PodStatus {
 	case api.PodSucceeded:
 		phase = v1.PodSucceeded
 	case api.PodFailed:
-		phase = v1.PodFailed
+		// If we set the pod to Failed in K8s, it never comes
+		// back out of that phase A failed pod in kip that should
+		// be restarted is "pending" in k8s
+		if podShouldBeRestarted(milpaPod) {
+			phase = v1.PodPending
+		} else {
+			phase = v1.PodFailed
+		}
 	case api.PodTerminated:
 		phase = v1.PodFailed
 	}

--- a/pkg/server/pod_controller_utils.go
+++ b/pkg/server/pod_controller_utils.go
@@ -123,9 +123,13 @@ func computePodPhase(policy api.RestartPolicy, unitstatus []api.UnitStatus, podN
 	return phase, failMsg
 }
 
+func podShouldBeRestarted(pod *api.Pod) bool {
+	return pod.Status.StartFailures <= allowedStartFailures &&
+		pod.Spec.RestartPolicy != api.RestartPolicyNever
+}
+
 func remedyFailedPod(pod *api.Pod, podRegistry *registry.PodRegistry) {
-	if pod.Status.StartFailures <= allowedStartFailures &&
-		pod.Spec.RestartPolicy != api.RestartPolicyNever {
+	if podShouldBeRestarted(pod) {
 		msg := fmt.Sprintf("Pod %s has failed to start %d times, retrying",
 			pod.Name, pod.Status.StartFailures)
 		klog.Warningf("%s", msg)


### PR DESCRIPTION
When a pod or cell fails in kip, the pod should behave similarly to a pod/container failing in kubelet.  The pod should be restarted on a new cell, similar to a container being recreated (depending on the pod's restart policy)

In k8s, if a pod enters into a terminal state, it never leaves that state.  To deal with this, lets reset a failed pod back to `Pending` in k8s if the pod will be restarted by kip.