### PR TITLE
Fix pod status updates

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -614,7 +614,6 @@ func (p *InstanceProvider) CreatePod(ctx context.Context, pod *v1.Pod) error {
 		klog.Errorf("CreatePod %q: %v", pod.Name, err)
 		return err
 	}
-	p.podNotifier(pod)
 	return nil
 }
 
@@ -638,7 +637,6 @@ func (p *InstanceProvider) UpdatePod(ctx context.Context, pod *v1.Pod) error {
 		klog.Errorf("UpdatePod %q: %v", pod.Name, err)
 		return err
 	}
-	p.podNotifier(pod)
 	return nil
 }
 
@@ -662,7 +660,6 @@ func (p *InstanceProvider) DeletePod(ctx context.Context, pod *v1.Pod) (err erro
 		klog.Errorf("DeletePod %q: %v", pod.Name, err)
 		return err
 	}
-	p.podNotifier(pod)
 	return nil
 }
 


### PR DESCRIPTION
The pod status notifier callback should only be called when the pod
status has changed in Kip, and not from any VK API method. VK can't
handle asynchronous status updates that come from an API method it's
calling in Kip.