### PR TITLE
Add EFS support to TF example

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -83,6 +83,25 @@ resource "aws_route_table_association" "route-table-to-subnet" {
   route_table_id = aws_route_table.route-table.id
 }
 
+resource "aws_efs_file_system" "efs" {
+  count = var.efs-enable ? 1 : 0
+  performance_mode = var.efs-performance-mode
+  provisioned_throughput_in_mibps = var.efs-provisioned-throughput-in-mibps
+  throughput_mode = var.efs-throughput-mode
+  tags = {
+    "Name" = "${var.cluster-name}"
+  }
+}
+
+resource "aws_efs_mount_target" "efs" {
+  count = var.efs-enable ? 1 : 0
+  file_system_id = aws_efs_file_system.efs[0].id
+  subnet_id      = aws_subnet.subnet.id
+  security_groups = [
+    aws_security_group.kubernetes.id
+  ]
+}
+
 resource "aws_security_group" "kubernetes" {
   name        = "kubernetes"
   description = "Main kubernetes security group"

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -1,3 +1,7 @@
 output "node-ip" {
   value = aws_instance.k8s-node.public_ip
 }
+
+output "efs-ip" {
+  value = aws_efs_mount_target.efs.*.ip_address
+}

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -42,3 +42,27 @@ variable "node-ami" {
 variable "kustomize-dir" {
   default = "../manifests/virtual-kubelet/base"
 }
+
+variable "efs-enable" {
+  type    = bool
+  default = false
+  description = "Create an EFS volume cells and/or pods in the VPC can mount and use."
+}
+
+variable "efs-performance-mode" {
+  type        = string
+  default     = "generalPurpose"
+  description = "Optional. The file system performance mode. Can be either generalPurpose or maxIO."
+}
+
+variable "efs-provisioned-throughput-in-mibps" {
+  type        = number
+  default     = 0
+  description = "Optional. The throughput, measured in MiB/s, that you want to provision for the file system. Only applicable with efs-throughput-mode set to provisioned."
+}
+
+variable "efs-throughput-mode" {
+  type        = string
+  default     = "bursting"
+  description = "Optional. Throughput mode for the file system. Defaults to bursting. Valid values: bursting, provisioned. When using provisioned, also set efs-provisioned-throughput-in-mibps."
+}


### PR DESCRIPTION
This adds the ability to create an EFS filesystem and mount target on AWS when using the TF example, so cells and pods have access to a simple storage option. I kept it disabled by default.

The main use case for now is to enable cells to cache images, speeding up subsequent pod starts. Right now one can add a cloud init file that will have cells mount in the EFS volume under /tmp/tosi (or symlink it there), effectively sharing an image cache for all pods. Note: this use case relies on https://github.com/elotl/tosi/pull/6; the current AMIs have an older version of tosi.