### PR TITLE
Pull in logs changes from VK

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -890,7 +890,7 @@
   revision = "c0381df9dbcd89a25594f53d49478f9cd97657ce"
 
 [[projects]]
-  digest = "1:ee29cb0ae9cc471817ddfdf0173e8706a8ec227f140c33e30634503917915ced"
+  digest = "1:0040952be0fb9f9105196a492c940071c8700c3d41c62e82a8d2f65e29d3e35a"
   name = "github.com/virtual-kubelet/virtual-kubelet"
   packages = [
     "errdefs",
@@ -902,8 +902,7 @@
     "trace/opencensus",
   ]
   pruneopts = "UT"
-  revision = "e6e1dbed870de9c9716ac8309eeec11b9ea67ebd"
-  version = "v1.2.1"
+  revision = "8fc8b69d8f532e4a613ddd147ac283b7f26d0344"
 
 [[projects]]
   digest = "1:36775a135c00ff94c2ab9d4de842ae9bf95f45d2159ade2b033f3ecbafa69423"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,7 +43,7 @@
 
 [[constraint]]
   name = "github.com/virtual-kubelet/virtual-kubelet"
-  version = "1.2.1"
+  revision = "8fc8b69d8f532e4a613ddd147ac283b7f26d0344"
 
 [[constraint]]
   name = "go.opencensus.io"

--- a/pkg/server/getcontainerlogs.go
+++ b/pkg/server/getcontainerlogs.go
@@ -36,9 +36,7 @@ func (p *InstanceProvider) GetContainerLogs(ctx context.Context, namespace, podN
 	defer span.End()
 	ctx = addAttributes(ctx, span, namespaceKey, namespace, nameKey, podName, containerNameKey, containerName)
 	klog.V(5).Infof("GetContainerLogs %+v", opts)
-	// Pending PR: https://github.com/virtual-kubelet/virtual-kubelet/pull/806
-	// follow := opts.Follow
-	follow := false
+	follow := opts.Follow
 	podName = util.WithNamespace(namespace, podName)
 	node, err := p.GetNodeForRunningPod(podName, "")
 	if !follow || err != nil || node == nil || len(node.Status.Addresses) == 0 {

--- a/vendor/github.com/virtual-kubelet/virtual-kubelet/node/api/helpers.go
+++ b/vendor/github.com/virtual-kubelet/virtual-kubelet/node/api/helpers.go
@@ -56,16 +56,14 @@ type flushWriter struct {
 }
 
 type writeFlusher interface {
-	Flush() error
+	Flush()
 	Write([]byte) (int, error)
 }
 
 func (fw *flushWriter) Write(p []byte) (int, error) {
 	n, err := fw.w.Write(p)
 	if n > 0 {
-		if err := fw.w.Flush(); err != nil {
-			return n, err
-		}
+		fw.w.Flush()
 	}
 	return n, err
 }

--- a/vendor/github.com/virtual-kubelet/virtual-kubelet/node/pod.go
+++ b/vendor/github.com/virtual-kubelet/virtual-kubelet/node/pod.go
@@ -30,6 +30,12 @@ import (
 
 const (
 	podStatusReasonProviderFailed = "ProviderFailed"
+	podEventCreateFailed          = "ProviderCreateFailed"
+	podEventCreateSuccess         = "ProviderCreateSuccess"
+	podEventDeleteFailed          = "ProviderDeleteFailed"
+	podEventDeleteSuccess         = "ProviderDeleteSuccess"
+	podEventUpdateFailed          = "ProviderUpdateFailed"
+	podEventUpdateSuccess         = "ProviderUpdateSuccess"
 )
 
 func addPodAttributes(ctx context.Context, span trace.Span, pod *corev1.Pod) context.Context {
@@ -72,16 +78,22 @@ func (pc *PodController) createOrUpdatePod(ctx context.Context, pod *corev1.Pod)
 			log.G(ctx).Debugf("Pod %s exists, updating pod in provider", podFromProvider.Name)
 			if origErr := pc.provider.UpdatePod(ctx, podForProvider); origErr != nil {
 				pc.handleProviderError(ctx, span, origErr, pod)
+				pc.recorder.Event(pod, corev1.EventTypeWarning, podEventUpdateFailed, origErr.Error())
+
 				return origErr
 			}
 			log.G(ctx).Info("Updated pod in provider")
+			pc.recorder.Event(pod, corev1.EventTypeNormal, podEventUpdateSuccess, "Update pod in provider successfully")
+
 		}
 	} else {
 		if origErr := pc.provider.CreatePod(ctx, podForProvider); origErr != nil {
 			pc.handleProviderError(ctx, span, origErr, pod)
+			pc.recorder.Event(pod, corev1.EventTypeWarning, podEventCreateFailed, origErr.Error())
 			return origErr
 		}
 		log.G(ctx).Info("Created pod in provider")
+		pc.recorder.Event(pod, corev1.EventTypeNormal, podEventCreateSuccess, "Create pod in provider successfully")
 	}
 	return nil
 }
@@ -140,9 +152,10 @@ func (pc *PodController) deletePod(ctx context.Context, pod *corev1.Pod) error {
 	err := pc.provider.DeletePod(ctx, pod.DeepCopy())
 	if err != nil {
 		span.SetStatus(err)
+		pc.recorder.Event(pod, corev1.EventTypeWarning, podEventDeleteFailed, err.Error())
 		return err
 	}
-
+	pc.recorder.Event(pod, corev1.EventTypeNormal, podEventDeleteSuccess, "Delete pod in provider successfully")
 	log.G(ctx).Debug("Deleted pod from provider")
 
 	return nil
@@ -176,7 +189,6 @@ func (pc *PodController) updatePodStatus(ctx context.Context, podFromKubernetes 
 	// the pod status, and we should be the sole writers of the pod status, we can blind overwrite it. Therefore
 	// we need to copy the pod and set ResourceVersion to 0.
 	podFromProvider.ResourceVersion = "0"
-
 	if _, err := pc.client.Pods(podFromKubernetes.Namespace).UpdateStatus(podFromProvider); err != nil {
 		span.SetStatus(err)
 		return pkgerrors.Wrap(err, "error while updating pod status in kubernetes")
@@ -201,6 +213,10 @@ func (pc *PodController) enqueuePodStatusUpdate(ctx context.Context, q workqueue
 		if obj, ok := pc.knownPods.Load(key); ok {
 			kpod := obj.(*knownPod)
 			kpod.Lock()
+			if cmp.Equal(kpod.lastPodStatusReceivedFromProvider, pod) {
+				kpod.Unlock()
+				return
+			}
 			kpod.lastPodStatusReceivedFromProvider = pod
 			kpod.Unlock()
 			q.AddRateLimited(key)


### PR DESCRIPTION
Now that https://github.com/virtual-kubelet/virtual-kubelet/pull/806 has been merged, we can improve how getting container logs behaves:
- Support for `-f`.
- Same default options as kubelet (getting all logs by default).