### PR TITLE
Save root device name when looking up image

### DIFF
--- a/pkg/server/cloud/aws/aws_functional_test.go
+++ b/pkg/server/cloud/aws/aws_functional_test.go
@@ -33,6 +33,7 @@ const (
 	vpcID            = "vpc-841834e2"
 	defaultSubnetID  = "subnet-12a8a13f"
 	imageAmi         = "ami-e2dea19d"
+	rootDevice       = "xvda" // Update if imageAmi is changed.
 	instanceType     = "t2.nano"
 )
 
@@ -78,7 +79,7 @@ func TestAWSCloud(t *testing.T) {
 	subnetID := defaultSubnetID
 	c, err := NewEC2Client(controllerID, controllerID, vpcID, subnetID, "")
 	assert.Nil(t, err)
-	ts, err := functional.SetupCloudFunctionalTest(t, c, imageAmi, instanceType)
+	ts, err := functional.SetupCloudFunctionalTest(t, c, imageAmi, rootDevice, instanceType)
 	if err != nil {
 		assert.FailNow(t, "Failed to setup functional test: %s", err.Error())
 	}
@@ -87,6 +88,6 @@ func TestAWSCloud(t *testing.T) {
 		functional.ContainerAuthTest(t, ts.CloudClient)
 	})
 	t.Run("BootSpotInstanceTest", func(t *testing.T) {
-		functional.RunSpotInstanceTest(t, ts.CloudClient, imageAmi)
+		functional.RunSpotInstanceTest(t, ts.CloudClient, imageAmi, rootDevice)
 	})
 }

--- a/pkg/server/cloud/aws/instances.go
+++ b/pkg/server/cloud/aws/instances.go
@@ -232,7 +232,7 @@ func bootImageSpecToDescribeImagesInput(spec cloud.BootImageSpec) *ec2.DescribeI
 	return input
 }
 
-func (e *AwsEC2) GetImageID(spec cloud.BootImageSpec) (cloud.Image, error) {
+func (e *AwsEC2) GetImage(spec cloud.BootImageSpec) (cloud.Image, error) {
 	input := bootImageSpecToDescribeImagesInput(spec)
 	resp, err := e.client.DescribeImages(input)
 	if err != nil {

--- a/pkg/server/cloud/azure/azure_functional_test.go
+++ b/pkg/server/cloud/azure/azure_functional_test.go
@@ -96,7 +96,7 @@ func TestAzureCloud(t *testing.T) {
 
 	syncImage(controllerID, cloud.BootImageSpec{}, az)
 
-	image, err := az.GetImageID(cloud.BootImageSpec{})
+	image, err := az.GetImage(cloud.BootImageSpec{})
 	if err != nil {
 		assert.Fail(t, "Azure functional test failed, could not get Image ID: %v", err.Error())
 		return

--- a/pkg/server/cloud/azure/azure_functional_test.go
+++ b/pkg/server/cloud/azure/azure_functional_test.go
@@ -96,14 +96,14 @@ func TestAzureCloud(t *testing.T) {
 
 	syncImage(controllerID, cloud.BootImageSpec{}, az)
 
-	imageID, err := az.GetImageID(cloud.BootImageSpec{})
+	image, err := az.GetImageID(cloud.BootImageSpec{})
 	if err != nil {
 		assert.Fail(t, "Azure functional test failed, could not get Image ID: %v", err.Error())
 		return
 	}
-	fmt.Println("found image:", imageID)
+	fmt.Println("found image:", image.ID)
 
-	ts, err := functional.SetupCloudFunctionalTest(t, az, imageID, instanceType)
+	ts, err := functional.SetupCloudFunctionalTest(t, az, image.ID, image.RootDevice, instanceType)
 	if err != nil {
 		assert.FailNow(t, "Failed to setup functional test: %s", err.Error())
 	}

--- a/pkg/server/cloud/azure/instances.go
+++ b/pkg/server/cloud/azure/instances.go
@@ -344,7 +344,7 @@ func matchSpec(properties map[string]string, spec cloud.BootImageSpec) bool {
 	return true
 }
 
-func (az *AzureClient) GetImageID(spec cloud.BootImageSpec) (cloud.Image, error) {
+func (az *AzureClient) GetImage(spec cloud.BootImageSpec) (cloud.Image, error) {
 	ctx := context.Background()
 	timeoutCtx, cancel := context.WithTimeout(ctx, azureDefaultTimeout)
 	defer cancel()

--- a/pkg/server/cloud/cloud.go
+++ b/pkg/server/cloud/cloud.go
@@ -42,8 +42,8 @@ const PodNameTagKey = "KipPodName"
 type CloudClient interface {
 	SetBootSecurityGroupIDs([]string)
 	GetBootSecurityGroupIDs() []string
-	StartNode(*api.Node, string) (*StartNodeResult, error)
-	StartSpotNode(*api.Node, string) (*StartNodeResult, error)
+	StartNode(*api.Node, Image, string) (*StartNodeResult, error)
+	StartSpotNode(*api.Node, Image, string) (*StartNodeResult, error)
 	// This should always be called from a goroutine as it can take a while
 	StopInstance(instanceID string) error
 	WaitForRunning(node *api.Node) ([]api.NetworkAddress, error)
@@ -54,7 +54,7 @@ type CloudClient interface {
 	ListInstances() ([]CloudInstance, error)
 	ResizeVolume(node *api.Node, size int64) (error, bool)
 	GetRegistryAuth() (string, string, error)
-	GetImageID(spec BootImageSpec) (string, error)
+	GetImageID(spec BootImageSpec) (Image, error)
 	SetSustainedCPU(*api.Node, bool) error
 	AddInstanceTags(string, map[string]string) error
 	ConnectWithPublicIPs() bool
@@ -115,6 +115,7 @@ type SubnetAttributes struct {
 type Image struct {
 	ID           string
 	Name         string
+	RootDevice   string
 	CreationTime *time.Time
 }
 

--- a/pkg/server/cloud/cloud.go
+++ b/pkg/server/cloud/cloud.go
@@ -54,7 +54,7 @@ type CloudClient interface {
 	ListInstances() ([]CloudInstance, error)
 	ResizeVolume(node *api.Node, size int64) (error, bool)
 	GetRegistryAuth() (string, string, error)
-	GetImageID(spec BootImageSpec) (Image, error)
+	GetImage(spec BootImageSpec) (Image, error)
 	SetSustainedCPU(*api.Node, bool) error
 	AddInstanceTags(string, map[string]string) error
 	ConnectWithPublicIPs() bool

--- a/pkg/server/cloud/mock.go
+++ b/pkg/server/cloud/mock.go
@@ -40,7 +40,7 @@ type MockCloudClient struct {
 	Lister              func() ([]CloudInstance, error)
 	Resizer             func(node *api.Node, size int64) (error, bool)
 	ContainerAuthorizer func() (string, string, error)
-	ImageIDGetter       func(BootImageSpec) (Image, error)
+	ImageGetter         func(BootImageSpec) (Image, error)
 
 	InstanceListerFilter func([]string) ([]CloudInstance, error)
 	InstanceLister       func() ([]CloudInstance, error)
@@ -97,8 +97,8 @@ func (m *MockCloudClient) GetRegistryAuth() (string, string, error) {
 	return m.ContainerAuthorizer()
 }
 
-func (m *MockCloudClient) GetImageID(spec BootImageSpec) (Image, error) {
-	return m.ImageIDGetter(spec)
+func (m *MockCloudClient) GetImage(spec BootImageSpec) (Image, error) {
+	return m.ImageGetter(spec)
 }
 
 func (m *MockCloudClient) SetSustainedCPU(n *api.Node, enabled bool) error {

--- a/pkg/server/cloud/mock.go
+++ b/pkg/server/cloud/mock.go
@@ -33,14 +33,14 @@ type MockCloudClient struct {
 	VPCCIDRs     []string
 	Subnets      []SubnetAttributes
 
-	Starter             func(node *api.Node, metadata string) (*StartNodeResult, error)
-	SpotStarter         func(node *api.Node, metadata string) (*StartNodeResult, error)
+	Starter             func(node *api.Node, image Image, metadata string) (*StartNodeResult, error)
+	SpotStarter         func(node *api.Node, image Image, metadata string) (*StartNodeResult, error)
 	Stopper             func(instanceID string) error
 	Waiter              func(node *api.Node) ([]api.NetworkAddress, error)
 	Lister              func() ([]CloudInstance, error)
 	Resizer             func(node *api.Node, size int64) (error, bool)
 	ContainerAuthorizer func() (string, string, error)
-	ImageIDGetter       func(BootImageSpec) (string, error)
+	ImageIDGetter       func(BootImageSpec) (Image, error)
 
 	InstanceListerFilter func([]string) ([]CloudInstance, error)
 	InstanceLister       func() ([]CloudInstance, error)
@@ -73,12 +73,12 @@ func (m *MockCloudClient) GetBootSecurityGroupIDs() []string {
 	return nil
 }
 
-func (m *MockCloudClient) StartNode(node *api.Node, metadata string) (*StartNodeResult, error) {
-	return m.Starter(node, metadata)
+func (m *MockCloudClient) StartNode(node *api.Node, image Image, metadata string) (*StartNodeResult, error) {
+	return m.Starter(node, image, metadata)
 }
 
-func (m *MockCloudClient) StartSpotNode(node *api.Node, metadata string) (*StartNodeResult, error) {
-	return m.SpotStarter(node, metadata)
+func (m *MockCloudClient) StartSpotNode(node *api.Node, image Image, metadata string) (*StartNodeResult, error) {
+	return m.SpotStarter(node, image, metadata)
 }
 
 func (m *MockCloudClient) StopInstance(instanceID string) error {
@@ -97,7 +97,7 @@ func (m *MockCloudClient) GetRegistryAuth() (string, string, error) {
 	return m.ContainerAuthorizer()
 }
 
-func (m *MockCloudClient) GetImageID(spec BootImageSpec) (string, error) {
+func (m *MockCloudClient) GetImageID(spec BootImageSpec) (Image, error) {
 	return m.ImageIDGetter(spec)
 }
 
@@ -336,7 +336,7 @@ func NewMockClient() *MockCloudClient {
 		return status
 	}
 
-	net.Starter = func(node *api.Node, metadata string) (*StartNodeResult, error) {
+	net.Starter = func(node *api.Node, image Image, metadata string) (*StartNodeResult, error) {
 		inst := CloudInstance{
 			ID:       node.Status.InstanceID,
 			NodeName: node.Name,

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -489,7 +489,7 @@ func validateBootImageSpec(spec cloud.BootImageSpec, cloudClient cloud.CloudClie
 	if err != nil {
 		return util.WrapError(err, "could not get machine image for %v", spec)
 	}
-	if img == "" {
+	if img.ID == "" {
 		return fmt.Errorf("could not find machine image for %v", spec)
 	}
 	return nil

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -485,7 +485,7 @@ func validateServerConfigFile(cf *ServerConfigFile) field.ErrorList {
 }
 
 func validateBootImageSpec(spec cloud.BootImageSpec, cloudClient cloud.CloudClient) error {
-	img, err := cloudClient.GetImageID(spec)
+	img, err := cloudClient.GetImage(spec)
 	if err != nil {
 		return util.WrapError(err, "could not get machine image for %v", spec)
 	}

--- a/pkg/server/nodemanager/node_controller.go
+++ b/pkg/server/nodemanager/node_controller.go
@@ -152,7 +152,7 @@ func (c *NodeController) doPoolsCalculation() (map[string]string, error) {
 	}
 
 	// If we can't get the boot image, just use the old value for the image
-	newBootImage, err := c.imageSpecToID(c.BootImageSpec)
+	newBootImage, err := c.imageSpecToImage(c.BootImageSpec)
 	if err != nil {
 		if BootImage.ID == "" {
 			return nil, util.WrapError(err, "Could not get latest boot image")
@@ -710,7 +710,7 @@ func (c *NodeController) requestNode(nodeReq NodeRequest, podNodeMapping map[str
 	}
 }
 
-func (c *NodeController) imageSpecToID(spec cloud.BootImageSpec) (cloud.Image, error) {
+func (c *NodeController) imageSpecToImage(spec cloud.BootImageSpec) (cloud.Image, error) {
 	var img cloud.Image
 	obj, exists := c.ImageIdCache.Get(spec.String())
 	if obj != nil {
@@ -718,7 +718,7 @@ func (c *NodeController) imageSpecToID(spec cloud.BootImageSpec) (cloud.Image, e
 	}
 	if !exists || img.ID == "" {
 		var err error
-		img, err = c.CloudClient.GetImageID(spec)
+		img, err = c.CloudClient.GetImage(spec)
 		if err != nil {
 			klog.Errorf("resolving image spec %v to image ID: %v",
 				spec, err)
@@ -726,7 +726,7 @@ func (c *NodeController) imageSpecToID(spec cloud.BootImageSpec) (cloud.Image, e
 		}
 		c.ImageIdCache.Add(spec.String(), img, 5*time.Minute,
 			func(obj interface{}) {
-				_, _ = c.imageSpecToID(spec)
+				_, _ = c.imageSpecToImage(spec)
 			})
 		klog.V(2).Infof("latest image for spec %v: %v", spec, img)
 	}

--- a/pkg/server/nodemanager/node_controller.go
+++ b/pkg/server/nodemanager/node_controller.go
@@ -47,7 +47,7 @@ var (
 	HealthyTimeout      time.Duration = 90 * time.Second
 	HealthcheckPause    time.Duration = 5 * time.Second
 	SpotRequestPause    time.Duration = 60 * time.Second
-	BootImage           string        = ""
+	BootImage           cloud.Image   = cloud.Image{}
 	MaxBootPerIteration int           = 10
 	itzoDir             string        = "/tmp/itzo"
 )
@@ -154,23 +154,23 @@ func (c *NodeController) doPoolsCalculation() (map[string]string, error) {
 	// If we can't get the boot image, just use the old value for the image
 	newBootImage, err := c.imageSpecToID(c.BootImageSpec)
 	if err != nil {
-		if BootImage == "" {
+		if BootImage.ID == "" {
 			return nil, util.WrapError(err, "Could not get latest boot image")
 		} else {
-			klog.Warningf("Could not get latest boot image: %s, using stored value for boot image: %s", err, BootImage)
+			klog.Warningf("Could not get latest boot image: %s, using stored value for boot image: %v", err, BootImage)
 			newBootImage = BootImage
 		}
 	}
 	BootImage = newBootImage
 
-	if BootImage == "" {
+	if BootImage.ID == "" {
 		return nil, fmt.Errorf("can not create create new nodes: empty value for machine image.  Please ensure boot image spec maps to a machine image: %v", c.BootImageSpec)
 	}
 	startNodes, stopNodes, podNodeMap := c.NodeScaler.Compute(nodes.Items, pods.Items)
 	if podNodeMap == nil {
 		return nil, fmt.Errorf("Error computing new node pools, this is likely a problem with the DB. Not updating pod-node bindings")
 	}
-	c.startNodes(startNodes)
+	c.startNodes(startNodes, BootImage)
 	for _, node := range stopNodes {
 		err := c.stopSingleNode(node)
 		if err != nil {
@@ -225,7 +225,7 @@ func (c *NodeController) getCloudInitContents() (string, error) {
 	return metadata, nil
 }
 
-func (c *NodeController) startNodes(nodes []*api.Node) {
+func (c *NodeController) startNodes(nodes []*api.Node, image cloud.Image) {
 	if len(nodes) <= 0 {
 		return
 	}
@@ -252,7 +252,7 @@ func (c *NodeController) startNodes(nodes []*api.Node) {
 			klog.Errorf("Error creating node in registry: %v", err)
 			continue
 		}
-		go c.startSingleNode(newNode, metadata)
+		go c.startSingleNode(newNode, image, metadata)
 	}
 }
 
@@ -274,15 +274,15 @@ func (c *NodeController) handleStartNodeError(node *api.Node, err error, isSpot 
 	}
 }
 
-func (c *NodeController) startSingleNode(node *api.Node, cloudInitData string) error {
+func (c *NodeController) startSingleNode(node *api.Node, image cloud.Image, cloudInitData string) error {
 	var (
 		startResult *cloud.StartNodeResult
 		err         error
 	)
 	if node.Spec.Spot {
-		startResult, err = c.CloudClient.StartSpotNode(node, cloudInitData)
+		startResult, err = c.CloudClient.StartSpotNode(node, image, cloudInitData)
 	} else {
-		startResult, err = c.CloudClient.StartNode(node, cloudInitData)
+		startResult, err = c.CloudClient.StartNode(node, image, cloudInitData)
 	}
 	if err != nil {
 		c.handleStartNodeError(node, err, false)
@@ -710,25 +710,25 @@ func (c *NodeController) requestNode(nodeReq NodeRequest, podNodeMapping map[str
 	}
 }
 
-func (c *NodeController) imageSpecToID(spec cloud.BootImageSpec) (string, error) {
-	img := ""
+func (c *NodeController) imageSpecToID(spec cloud.BootImageSpec) (cloud.Image, error) {
+	var img cloud.Image
 	obj, exists := c.ImageIdCache.Get(spec.String())
 	if obj != nil {
-		img = obj.(string)
+		img = obj.(cloud.Image)
 	}
-	if !exists || img == "" {
+	if !exists || img.ID == "" {
 		var err error
 		img, err = c.CloudClient.GetImageID(spec)
 		if err != nil {
 			klog.Errorf("resolving image spec %v to image ID: %v",
 				spec, err)
-			return "", err
+			return img, err
 		}
 		c.ImageIdCache.Add(spec.String(), img, 5*time.Minute,
 			func(obj interface{}) {
 				_, _ = c.imageSpecToID(spec)
 			})
-		klog.V(2).Infof("latest image for spec %v: '%s'", spec, img)
+		klog.V(2).Infof("latest image for spec %v: %v", spec, img)
 	}
 	return img, nil
 }

--- a/pkg/server/nodemanager/node_controller_test.go
+++ b/pkg/server/nodemanager/node_controller_test.go
@@ -335,7 +335,7 @@ func TestBufferingAndDispatchingTogether(t *testing.T) {
 		SpotStarter: StartReturnsOK,
 		Stopper:     ReturnNil,
 		Waiter:      ReturnAddresses,
-		ImageIDGetter: func(spec cloud.BootImageSpec) (cloud.Image, error) {
+		ImageGetter: func(spec cloud.BootImageSpec) (cloud.Image, error) {
 			return cloud.Image{}, nil
 		},
 	}
@@ -537,7 +537,7 @@ func TestRemovePodFromNode(t *testing.T) {
 	//todo
 }
 
-func TestImageSpecToID(t *testing.T) {
+func TestImageSpecToImage(t *testing.T) {
 	ctl, closer := MakeNodeController()
 	defer closer()
 	ctl.CloudClient = &cloud.MockCloudClient{
@@ -545,7 +545,7 @@ func TestImageSpecToID(t *testing.T) {
 		SpotStarter: StartReturnsOK,
 		Stopper:     ReturnNil,
 		Waiter:      ReturnAddresses,
-		ImageIDGetter: func(spec cloud.BootImageSpec) (cloud.Image, error) {
+		ImageGetter: func(spec cloud.BootImageSpec) (cloud.Image, error) {
 			return cloud.Image{
 				ID:         "my-image-id",
 				Name:       "my-image-name",
@@ -553,18 +553,18 @@ func TestImageSpecToID(t *testing.T) {
 			}, nil
 		},
 	}
-	img, err := ctl.imageSpecToID(defaultBootImageSpec)
+	img, err := ctl.imageSpecToImage(defaultBootImageSpec)
 	assert.Nil(t, err)
 	assert.Equal(t, defaultBootImageID, img.ID)
 	spec := cloud.BootImageSpec{
 		"name": "my-name-*",
 	}
-	img, err = ctl.imageSpecToID(spec)
+	img, err = ctl.imageSpecToImage(spec)
 	assert.Nil(t, err)
 	assert.Equal(t, "my-image-id", img.ID)
 }
 
-func TestImageSpecToIDFailure(t *testing.T) {
+func TestImageSpecToImageFailure(t *testing.T) {
 	t.Parallel()
 	ctl, closer := MakeNodeController()
 	defer closer()
@@ -573,14 +573,14 @@ func TestImageSpecToIDFailure(t *testing.T) {
 		SpotStarter: StartReturnsOK,
 		Stopper:     ReturnNil,
 		Waiter:      ReturnAddresses,
-		ImageIDGetter: func(spec cloud.BootImageSpec) (cloud.Image, error) {
-			return cloud.Image{}, fmt.Errorf("Testing GetImageID() failure")
+		ImageGetter: func(spec cloud.BootImageSpec) (cloud.Image, error) {
+			return cloud.Image{}, fmt.Errorf("Testing GetImage() failure")
 		},
 	}
 	spec := cloud.BootImageSpec{
 		"name": "my-name-*",
 	}
-	_, err := ctl.imageSpecToID(spec)
+	_, err := ctl.imageSpecToImage(spec)
 	assert.NotNil(t, err)
 }
 
@@ -625,7 +625,7 @@ func TestDoPoolsCalculation(t *testing.T) {
 		Stopper:      ReturnNil,
 		Waiter:       ReturnAddresses,
 		RouteRemover: StringStringReturnNil,
-		ImageIDGetter: func(spec cloud.BootImageSpec) (cloud.Image, error) {
+		ImageGetter: func(spec cloud.BootImageSpec) (cloud.Image, error) {
 			return cloud.Image{}, nil
 		},
 	}

--- a/pkg/server/nodemanager/node_controller_test.go
+++ b/pkg/server/nodemanager/node_controller_test.go
@@ -59,12 +59,12 @@ func FakeLister() ([]cloud.CloudInstance, error) {
 	return nil, nil
 }
 
-func StartReturnsOK(node *api.Node, metadata string) (*cloud.StartNodeResult, error) {
+func StartReturnsOK(node *api.Node, image cloud.Image, metadata string) (*cloud.StartNodeResult, error) {
 	result := &cloud.StartNodeResult{"instID", "us-east-1a"}
 	return result, nil
 }
 
-func StartFails(node *api.Node, metadata string) (*cloud.StartNodeResult, error) {
+func StartFails(node *api.Node, image cloud.Image, metadata string) (*cloud.StartNodeResult, error) {
 	return nil, fmt.Errorf("Testing, purposefully returning error")
 }
 
@@ -94,8 +94,11 @@ func MakeNodeController() (*NodeController, func()) {
 		Waiter:       ReturnAddresses,
 		RouteRemover: StringStringReturnNil,
 	}
+	defaultBootImage := cloud.Image{
+		ID: defaultBootImageID,
+	}
 	imageIdCache := timeoutmap.New(false, make(chan struct{}))
-	imageIdCache.Add(defaultBootImageSpec.String(), defaultBootImageID, 5*time.Minute, timeoutmap.Noop)
+	imageIdCache.Add(defaultBootImageSpec.String(), defaultBootImage, 5*time.Minute, timeoutmap.Noop)
 	fakeCertFactory, _ := certs.NewFake()
 	cloudStatus, _ := cloud.NewLinkedAZSubnetStatus(cloud.NewMockClient())
 	ciFile, _ := cloudinitfile.New("")
@@ -188,7 +191,7 @@ func StartAFewNodes(t *testing.T, numNodes int, spotNode bool) {
 		}
 		startNodes = append(startNodes, node)
 	}
-	ctl.startNodes(startNodes)
+	ctl.startNodes(startNodes, cloud.Image{})
 	// starting happens in a goroutine so we'll sleep here
 	time.Sleep(1 * time.Second)
 	nodes, err := ctl.NodeRegistry.ListNodes(registry.MatchAllNodes)
@@ -218,7 +221,7 @@ func TestStartNodeHealthcheckFails(t *testing.T) {
 	ctl.NodeClientFactory.(*nodeclient.MockItzoClientFactory).Health = func() error {
 		return fmt.Errorf("fail")
 	}
-	ctl.startNodes([]*api.Node{api.GetFakeNode()})
+	ctl.startNodes([]*api.Node{api.GetFakeNode()}, cloud.Image{})
 	time.Sleep(1 * time.Second)
 	nodes, err := ctl.NodeRegistry.ListAllNodes(registry.MatchAllNodes)
 	assert.Nil(t, err)
@@ -235,7 +238,7 @@ func TestStartNodeFails(t *testing.T) {
 	ctl.CloudClient = &cloud.MockCloudClient{
 		Starter: StartFails,
 	}
-	ctl.startNodes([]*api.Node{api.GetFakeNode()})
+	ctl.startNodes([]*api.Node{api.GetFakeNode()}, cloud.Image{})
 	time.Sleep(1 * time.Second)
 	nodes, err := ctl.NodeRegistry.ListAllNodes(registry.MatchAllNodes)
 	assert.Nil(t, err)
@@ -332,8 +335,8 @@ func TestBufferingAndDispatchingTogether(t *testing.T) {
 		SpotStarter: StartReturnsOK,
 		Stopper:     ReturnNil,
 		Waiter:      ReturnAddresses,
-		ImageIDGetter: func(spec cloud.BootImageSpec) (string, error) {
-			return "", nil
+		ImageIDGetter: func(spec cloud.BootImageSpec) (cloud.Image, error) {
+			return cloud.Image{}, nil
 		},
 	}
 	pod := api.GetFakePod()
@@ -542,19 +545,23 @@ func TestImageSpecToID(t *testing.T) {
 		SpotStarter: StartReturnsOK,
 		Stopper:     ReturnNil,
 		Waiter:      ReturnAddresses,
-		ImageIDGetter: func(spec cloud.BootImageSpec) (string, error) {
-			return "my-image-id", nil
+		ImageIDGetter: func(spec cloud.BootImageSpec) (cloud.Image, error) {
+			return cloud.Image{
+				ID:         "my-image-id",
+				Name:       "my-image-name",
+				RootDevice: "/dev/rootdev0",
+			}, nil
 		},
 	}
 	img, err := ctl.imageSpecToID(defaultBootImageSpec)
 	assert.Nil(t, err)
-	assert.Equal(t, defaultBootImageID, img)
+	assert.Equal(t, defaultBootImageID, img.ID)
 	spec := cloud.BootImageSpec{
 		"name": "my-name-*",
 	}
 	img, err = ctl.imageSpecToID(spec)
 	assert.Nil(t, err)
-	assert.Equal(t, "my-image-id", img)
+	assert.Equal(t, "my-image-id", img.ID)
 }
 
 func TestImageSpecToIDFailure(t *testing.T) {
@@ -566,8 +573,8 @@ func TestImageSpecToIDFailure(t *testing.T) {
 		SpotStarter: StartReturnsOK,
 		Stopper:     ReturnNil,
 		Waiter:      ReturnAddresses,
-		ImageIDGetter: func(spec cloud.BootImageSpec) (string, error) {
-			return "", fmt.Errorf("Testing GetImageID() failure")
+		ImageIDGetter: func(spec cloud.BootImageSpec) (cloud.Image, error) {
+			return cloud.Image{}, fmt.Errorf("Testing GetImageID() failure")
 		},
 	}
 	spec := cloud.BootImageSpec{
@@ -618,8 +625,8 @@ func TestDoPoolsCalculation(t *testing.T) {
 		Stopper:      ReturnNil,
 		Waiter:       ReturnAddresses,
 		RouteRemover: StringStringReturnNil,
-		ImageIDGetter: func(spec cloud.BootImageSpec) (string, error) {
-			return "", nil
+		ImageIDGetter: func(spec cloud.BootImageSpec) (cloud.Image, error) {
+			return cloud.Image{}, nil
 		},
 	}
 	// we create a new pod that needs a node and a node that

--- a/pkg/server/nodemanager/node_scaler.go
+++ b/pkg/server/nodemanager/node_scaler.go
@@ -100,7 +100,7 @@ func (s *BindingNodeScaler) createNodeForPod(pod *api.Pod) *api.Node {
 
 	node := api.NewNode()
 	node.Spec.InstanceType = pod.Spec.InstanceType
-	node.Spec.BootImage = BootImage
+	node.Spec.BootImage = BootImage.ID
 	node.Spec.Spot = isSpotPod
 	node.Spec.Resources = pod.Spec.Resources
 	// If we can resize, keep things simple and never enlarge the disk
@@ -119,7 +119,7 @@ func (s *BindingNodeScaler) createNodeForPod(pod *api.Pod) *api.Node {
 func (s *BindingNodeScaler) createNodeForStandbySpec(spec *StandbyNodeSpec) *api.Node {
 	node := api.NewNode()
 	node.Spec.InstanceType = spec.InstanceType
-	node.Spec.BootImage = BootImage
+	node.Spec.BootImage = BootImage.ID
 	node.Spec.Spot = spec.Spot
 	node.Spec.Resources.VolumeSize = s.defaultVolumeSize
 	return node


### PR DESCRIPTION
In the AWS backend, "xvda" is hardcoded when we call RunInstances(). However, the name of the root device depends on the AMI. We need to check and save RootDeviceName from DescribeImages(), and use it when creating a new instance.

This fixes #83