### PR TITLE
Generate server certificate in an init container

### DIFF
--- a/deploy/manifests/virtual-kubelet/base/deployment.yaml
+++ b/deploy/manifests/virtual-kubelet/base/deployment.yaml
@@ -38,6 +38,23 @@ spec:
                   - ""
               topologyKey: failure-domain.beta.kubernetes.io/zone
             weight: 100
+      initContainers:
+      - command:
+        - bash
+        - -c
+        - /opt/csr/get-cert.sh && mkdir -p /data/kubelet-pki && cp /opt/csr/$NODE_NAME.{key,crt} /data/kubelet-pki/
+        env:
+        - name: NODE_NAME
+          value: virtual-kubelet
+        image: elotl/init-cert:latest
+        imagePullPolicy: Always
+        name: init-cert
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /data
+          name: data
       containers:
       - command:
         - /virtual-kubelet
@@ -57,9 +74,9 @@ spec:
         - name: KUBELET_PORT
           value: "10666"
         - name: APISERVER_CERT_LOCATION
-          value: /var/lib/kubelet/pki/kubelet.crt
+          value: /opt/kip/data/kubelet-pki/virtual-kubelet.crt
         - name: APISERVER_KEY_LOCATION
-          value: /var/lib/kubelet/pki/kubelet.key
+          value: /opt/kip/data/kubelet-pki/virtual-kubelet.key
         - name: NODE_NAME
           valueFrom:
             fieldRef:
@@ -77,8 +94,6 @@ spec:
           mountPath: /opt/kip/data
         - name: provider-yaml
           mountPath: /etc/virtual-kubelet
-        - name: kubelet-pki
-          mountPath: /var/lib/kubelet/pki
         - name: xtables-lock
           mountPath: /run/xtables.lock
         - name: lib-modules
@@ -97,10 +112,6 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: provider-data
-      - name: kubelet-pki
-        hostPath:
-          path: /var/lib/kubelet/pki
-          type: Directory
       - name: provider-yaml
         configMap:
           name: virtual-kubelet-config

--- a/deploy/manifests/virtual-kubelet/base/deployment.yaml
+++ b/deploy/manifests/virtual-kubelet/base/deployment.yaml
@@ -42,10 +42,12 @@ spec:
       - command:
         - bash
         - -c
-        - /opt/csr/get-cert.sh && mkdir -p /data/kubelet-pki && cp /opt/csr/$NODE_NAME.{key,crt} /data/kubelet-pki/
+        - mkdir -p $CERT_DIR && /opt/csr/get-cert.sh
         env:
         - name: NODE_NAME
           value: virtual-kubelet
+        - name: CERT_DIR
+          value: /data/kubelet-pki
         image: elotl/init-cert:latest
         imagePullPolicy: Always
         name: init-cert

--- a/deploy/manifests/virtual-kubelet/base/sa.yaml
+++ b/deploy/manifests/virtual-kubelet/base/sa.yaml
@@ -107,16 +107,27 @@ rules:
       - get
   - apiGroups:
     - certificates.k8s.io
+    resourceNames:
+      - kubernetes.io/kubelet-serving
+    resources:
+      - signers
+    verbs:
+      - approve
+  - apiGroups:
+    - certificates.k8s.io
     resources:
       - certificatesigningrequests
-      - certificatesigningrequests/approval
-      - certificatesigningrequests/status
     verbs:
       - create
       - get
       - list
-      - update
       - watch
+  - apiGroups:
+    - certificates.k8s.io
+    resources:
+      - certificatesigningrequests/approval
+    verbs:
+      - update
   - apiGroups:
     - coordination.k8s.io
     resources:

--- a/deploy/manifests/virtual-kubelet/base/sa.yaml
+++ b/deploy/manifests/virtual-kubelet/base/sa.yaml
@@ -109,10 +109,13 @@ rules:
     - certificates.k8s.io
     resources:
       - certificatesigningrequests
+      - certificatesigningrequests/approval
+      - certificatesigningrequests/status
     verbs:
       - create
       - get
       - list
+      - update
       - watch
   - apiGroups:
     - coordination.k8s.io

--- a/scripts/init-cert/Dockerfile
+++ b/scripts/init-cert/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:stable-slim
+
+ENV DEBIAN_FRONTEND "noninteractive"
+
+RUN apt-get update -y && \
+        apt-get dist-upgrade -y && \
+        apt-get install -y curl gettext-base iproute2 openssl
+
+RUN mkdir -p /usr/local/bin
+
+RUN curl -fL https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl > /usr/local/bin/kubectl
+RUN chmod +x /usr/local/bin/kubectl
+
+RUN curl -fL https://github.com/ldx/token2kubeconfig/releases/download/v0.0.2/token2kubeconfig-amd64 > /usr/local/bin/token2kubeconfig
+RUN chmod +x /usr/local/bin/token2kubeconfig
+
+RUN mkdir -p /opt/csr
+COPY csr /opt/csr
+
+CMD /opt/csr/create.sh

--- a/scripts/init-cert/Dockerfile
+++ b/scripts/init-cert/Dockerfile
@@ -17,4 +17,4 @@ RUN chmod +x /usr/local/bin/token2kubeconfig
 RUN mkdir -p /opt/csr
 COPY csr /opt/csr
 
-CMD /opt/csr/create.sh
+CMD /opt/csr/get-cert.sh

--- a/scripts/init-cert/csr/create-csr.sh
+++ b/scripts/init-cert/csr/create-csr.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export NODE_NAME=${NODE_NAME:-virtual-kubelet}
+export CSR_NAME=${CSR_NAME:-$NODE_NAME-$(date +%s)}
+export INTERNAL_IP=$(ip route get 8.8.8.8 | grep src | head -n1 | awk '{print $7}')
+
+rm -f $NODE_NAME.key $NODE_NAME.csr $NODE_NAME.crt
+
+openssl genrsa -out $NODE_NAME.key 2048
+openssl req -new -key $NODE_NAME.key -out $NODE_NAME.csr -config <(envsubst < csr.conf)
+
+VK_CSR="$(base64 -w0 < $NODE_NAME.csr)" envsubst < csr.yaml

--- a/scripts/init-cert/csr/csr.conf
+++ b/scripts/init-cert/csr/csr.conf
@@ -1,0 +1,19 @@
+[req]
+days = 3650
+prompt = no
+req_extensions = v3_req
+distinguished_name = dn
+
+[dn]
+O=system:nodes
+CN=system:node:virtual-kubelet
+
+[v3_req]
+subjectAltName = @alt_names
+basicConstraints = CA:FALSE
+extendedKeyUsage = serverAuth
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+
+[alt_names]
+DNS.1 = ${NODE_NAME}
+IP.1 = ${INTERNAL_IP}

--- a/scripts/init-cert/csr/csr.yaml
+++ b/scripts/init-cert/csr/csr.yaml
@@ -1,0 +1,13 @@
+apiVersion: certificates.k8s.io/v1beta1
+kind: CertificateSigningRequest
+metadata:
+  name: ${CSR_NAME}
+spec:
+  groups:
+  - system:nodes
+  - system:authenticated
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+  request: ${VK_CSR}

--- a/scripts/init-cert/csr/get-cert.sh
+++ b/scripts/init-cert/csr/get-cert.sh
@@ -2,8 +2,17 @@
 
 set -euo pipefail
 
-echo "generating certificate for \"$NODE_NAME\""
+echo "generating certificate for \"$NODE_NAME\" in directory \"$CERT_DIR\""
 export NODE_NAME=$NODE_NAME
+
+[[ -d "$CERT_DIR" ]]
+
+if [[ -f "$CERT_DIR/$NODE_NAME.key" ]] && [[ -f "$CERT_DIR/$NODE_NAME.crt" ]]; then
+    echo "checking existing cert"
+    openssl x509 -in "$CERT_DIR/$NODE_NAME.crt" && \
+        echo "found valid certificate" && exit 0 || \
+        echo "invalid certificate \"$CERT_DIR/$NODE_NAME.crt\", recreating it"
+fi
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPT_DIR
@@ -29,5 +38,20 @@ while [[ $i -lt 30 ]]; do
     break
 done
 
-kubectl get csr $CSR_NAME -ojsonpath='{.status.certificate}' | base64 -d > $NODE_NAME.crt
+i=0
+CERT_DATA=""
+while [[ -z "$CERT_DATA" ]]; do
+    i=$((i+1))
+    if [[ $i -gt 30 ]]; then
+        echo "timeout waiting for CSR $CSR_NAME"
+    fi
+    sleep 1
+    CERT_DATA=$(kubectl get csr $CSR_NAME -ojsonpath='{.status.certificate}')
+done
+
+echo "$CERT_DATA" | base64 -d > $NODE_NAME.crt
+echo "generated certificate:"
 openssl x509 -text -in $NODE_NAME.crt
+
+cp $NODE_NAME.crt $CERT_DIR/
+cp $NODE_NAME.key $CERT_DIR/

--- a/scripts/init-cert/csr/get-cert.sh
+++ b/scripts/init-cert/csr/get-cert.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "generating certificate for \"$NODE_NAME\""
+export NODE_NAME=$NODE_NAME
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR
+
+KUBECONFIG=${KUBECONFIG:-""}
+if [[ -z $KUBECONFIG ]]; then
+    token2kubeconfig > kubeconfig
+    export KUBECONFIG=$(pwd)/kubeconfig
+fi
+
+export CSR_NAME="virtual-kubelet-$(date +%s)"
+
+./create-csr.sh | kubectl apply -f -
+
+i=0
+while [[ $i -lt 30 ]]; do
+    i=$((i+1))
+    kubectl get csr $CSR_NAME || {
+        sleep 1
+        continue
+    }
+    kubectl certificate approve $CSR_NAME
+    break
+done
+
+kubectl get csr $CSR_NAME -ojsonpath='{.status.certificate}' | base64 -d > $NODE_NAME.crt
+openssl x509 -text -in $NODE_NAME.crt


### PR DESCRIPTION
I added a simple init container to VK that generates a server certificate for serving the API. Unfortunately, we have to jump through a few extra hoops (approving the CSR ourselves) since VK uses its own service account for interacting with the control plane.

I made sure the certificate is only generated if it's missing or invalid.