### PR TITLE
Add more debug logging when creating provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+DKR=img
 GIT_VERSION=$(shell git describe --dirty)
 CURRENT_TIME=$(shell date +%Y%m%d%H%M%S)
 IMAGE_TAG=$(GIT_VERSION)
@@ -42,18 +43,18 @@ kipctl: $(PKG_SRC) $(VENDOR_SRC) $(KIPCTL_SRC)
 
 img: $(BINARIES)
 	@echo "Checking if IMAGE_TAG is set" && test -n "$(IMAGE_TAG)"
-	img build -t $(REGISTRY_REPO):$(IMAGE_TAG) \
+	$(DKR) build -t $(REGISTRY_REPO):$(IMAGE_TAG) \
 		-t $(REGISTRY_REPO):$(IMAGE_DEV_OR_LATEST) .
 
 login-img:
 	@echo "Checking if REGISTRY_USER is set" && test -n "$(REGISTRY_USER)"
 	@echo "Checking if REGISTRY_PASSWORD is set" && test -n "$(REGISTRY_PASSWORD)"
-	@img login -u "$(REGISTRY_USER)" -p "$(REGISTRY_PASSWORD)" "$(REGISTRY_SERVER)"
+	@$(DKR) login -u "$(REGISTRY_USER)" -p "$(REGISTRY_PASSWORD)" "$(REGISTRY_SERVER)"
 
 push-img: img
 	@echo "Checking if IMAGE_TAG is set" && test -n "$(IMAGE_TAG)"
-	img push $(REGISTRY_REPO):$(IMAGE_TAG)
-	img push $(REGISTRY_REPO):$(IMAGE_DEV_OR_LATEST)
+	$(DKR) push $(REGISTRY_REPO):$(IMAGE_TAG)
+	$(DKR) push $(REGISTRY_REPO):$(IMAGE_DEV_OR_LATEST)
 
 clean:
 	rm -f $(BINARIES)


### PR DESCRIPTION
Two changes:
- I added some V(5) logs when the provider is being created.
- In Makefile, one can now use the `DKR` environment variable to choose `img`, `docker` or any other command line compatible client for building and pushing the kip image, e.g. `make img DKR=docker` will build the image via docker.