### PR TITLE
fix up using imagePullSecrets in kip, be able to use dockerconfigjson

### DIFF
--- a/pkg/server/convert.go
+++ b/pkg/server/convert.go
@@ -514,6 +514,13 @@ func k8sToMilpaPod(pod *v1.Pod) (*api.Pod, error) {
 	milpapod.Labels = pod.Labels
 	milpapod.Annotations = pod.Annotations
 	milpapod.Spec.RestartPolicy = api.RestartPolicy(string(pod.Spec.RestartPolicy))
+	if len(pod.Spec.ImagePullSecrets) > 0 {
+		milpapod.Spec.ImagePullSecrets = make([]string, len(pod.Spec.ImagePullSecrets))
+		for i := range pod.Spec.ImagePullSecrets {
+			milpapod.Spec.ImagePullSecrets[i] = pod.Spec.ImagePullSecrets[i].Name
+		}
+	}
+
 	podsc := pod.Spec.SecurityContext
 	if podsc != nil {
 		mpsc := &api.PodSecurityContext{
@@ -686,6 +693,13 @@ func milpaToK8sPod(nodeName, internalIP string, milpaPod *api.Pod) (*v1.Pod, err
 	pod.Spec.NodeName = nodeName
 	pod.Spec.Volumes = []v1.Volume{}
 	pod.Spec.RestartPolicy = v1.RestartPolicy(string(milpaPod.Spec.RestartPolicy))
+	if len(milpaPod.Spec.ImagePullSecrets) > 0 {
+		pod.Spec.ImagePullSecrets = make([]v1.LocalObjectReference, len(milpaPod.Spec.ImagePullSecrets))
+		for i := range milpaPod.Spec.ImagePullSecrets {
+			pod.Spec.ImagePullSecrets[i].Name = milpaPod.Spec.ImagePullSecrets[i]
+		}
+	}
+
 	mpsc := milpaPod.Spec.SecurityContext
 	if mpsc != nil {
 		if pod.Spec.SecurityContext == nil {

--- a/pkg/server/pod_controller.go
+++ b/pkg/server/pod_controller.go
@@ -17,9 +17,11 @@ limitations under the License.
 package server
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -247,6 +249,84 @@ func (c *PodController) markFailedPod(pod *api.Pod, startFailure bool, msg strin
 	}()
 }
 
+func parseDockerConfigServer(serverURL string) (string, error) {
+	if !strings.HasPrefix(serverURL, "https://") &&
+		!strings.HasPrefix(serverURL, "http://") {
+		serverURL = "https://" + serverURL
+	}
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		return "", err
+	}
+	return parsed.Host, nil
+}
+
+const (
+	dockerServerKey       = "server"
+	dockerUsernameKey     = "username"
+	dockerPasswordKey     = "password"
+	dockerAuthsKey        = "auths"
+	dockerConcatedAuthKey = "auth"
+	dockerConfigJSONKey   = ".dockerconfigjson"
+)
+
+func parseDockerConfigCreds(dockerJSON []byte) (map[string]api.RegistryCredentials, error) {
+	// dockerJSON looks like
+	// {
+	//     "auths": {
+	//         "https://index.docker.io/v1/": {
+	//             "username": "myuser",
+	//             "password": "mypass",
+	//             "email": "doesnt@matter.com",
+	//             "auth": "base64(username:password)"
+	//         }
+	//         "689494258501.dkr.ecr.us-east-1.amazonaws.com": {
+	//              "auth": "base64(username:password)"
+	//         }
+	//     }
+	// }
+	type dockerConfig struct {
+		Auths map[string]map[string]string `json:"auths"`
+	}
+
+	var dockerCfg dockerConfig
+	err := json.Unmarshal(dockerJSON, &dockerCfg)
+	if err != nil {
+		return nil, util.WrapError(err, "Could not unmarshal dockerconfigjson")
+	}
+	creds := map[string]api.RegistryCredentials{}
+
+	for serverURL, serverCfg := range dockerCfg.Auths {
+		server, err := parseDockerConfigServer(serverURL)
+		if err != nil {
+			return nil, util.WrapError(err, "could not parse docker config json server: %s", serverURL)
+		}
+		username := serverCfg[dockerUsernameKey]
+		password := serverCfg[dockerPasswordKey]
+		// Some servers just have an auth section, try to parse that
+		if username == "" && password == "" {
+			if auth, ok := serverCfg[dockerConcatedAuthKey]; ok {
+				byteData, err := base64.StdEncoding.DecodeString(auth)
+				if err != nil {
+					return nil, util.WrapError(err, "docker config json file format error, could not decode auth for %s", serverURL)
+				}
+				parts := strings.SplitN(string(byteData), ":", 2)
+				if len(parts) < 2 {
+					return nil, util.WrapError(err, "docker config json file format error, could not find username and password in auth for server %s", serverURL)
+				}
+				username = parts[0]
+				password = parts[1]
+			}
+		}
+		creds[server] = api.RegistryCredentials{
+			Server:   server,
+			Username: string(username),
+			Password: string(password),
+		}
+	}
+	return creds, nil
+}
+
 func (c *PodController) loadRegistryCredentials(pod *api.Pod) (map[string]api.RegistryCredentials, error) {
 	allCreds := make(map[string]api.RegistryCredentials)
 	for _, secretName := range pod.Spec.ImagePullSecrets {
@@ -254,29 +334,34 @@ func (c *PodController) loadRegistryCredentials(pod *api.Pod) (map[string]api.Re
 		if err != nil {
 			return nil, util.WrapError(err, "could not get secret %s from api server", secretName)
 		}
-		server := s.Data["server"]
-		username, exists := s.Data["username"]
-		if !exists {
-			return nil, fmt.Errorf(
-				"could not find registry username in secret %s", secretName)
-		}
-		password, exists := s.Data["password"]
-		if !exists {
-			return nil, fmt.Errorf(
-				"could not find registry password in secret %s", secretName)
-		}
-		creds := api.RegistryCredentials{
-			Server:   string(server),
-			Username: string(username),
-			Password: string(password),
-		}
-		allCreds[string(server)] = creds
-		if creds.Username == "" {
-			klog.Warningf("Found empty username for image secret %s", secretName)
-		}
-		if creds.Password == "" {
-			// Reviewer: do you think its bad to leak this info?
-			klog.Warningf("Found empty password for secret %s", secretName)
+		if dockerJSON, ok := s.Data[dockerConfigJSONKey]; ok {
+			dockerCreds, err := parseDockerConfigCreds(dockerJSON)
+			if err != nil {
+				return nil, err
+			}
+			for k, v := range dockerCreds {
+				allCreds[k] = v
+			}
+		} else {
+			// This is the old server, username, password format
+			// I'm unsure if this can even be used in k8s?
+			server := s.Data[dockerServerKey]
+			username, exists := s.Data[dockerUsernameKey]
+			if !exists {
+				return nil, fmt.Errorf(
+					"could not find registry username in secret %s", secretName)
+			}
+			password, exists := s.Data[dockerPasswordKey]
+			if !exists {
+				return nil, fmt.Errorf(
+					"could not find registry password in secret %s", secretName)
+			}
+			creds := api.RegistryCredentials{
+				Server:   string(server),
+				Username: string(username),
+				Password: string(password),
+			}
+			allCreds[string(server)] = creds
 		}
 	}
 

--- a/pkg/server/pod_controller_test.go
+++ b/pkg/server/pod_controller_test.go
@@ -548,16 +548,6 @@ func TestParseDockerConfigCreds(t *testing.T) {
 			config: []byte(`{
     "auths": {
         "https://index.docker.io/v1/": {
-            "auth": "this*@aint--base_64"
-        }
-    }
-}`),
-			err: true,
-		},
-		{
-			config: []byte(`{
-    "auths": {
-        "https://index.docker.io/v1/": {
             "auth": "bXl1c2Vy"
         }
     }


### PR DESCRIPTION
K8s docs for image pull specs are here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

This is a first pass at being able to use image pull secrets created with kubectl.  It's not perfect (I think docker's config.json allows you to specify different creds for the same repo URL at different paths) but it's a decent start.

Creating docker secrets:
```bash
$ kubectl create secret docker-registry regcred \
    --docker-server=<server> \
    --docker-username=<username> \
    --docker-password=<password> \
    --docker-email=<docker-email>

$kubectl create secret generic file-regcred \ 
    --from-file=.dockerconfigjson=/home/myuser/.docker/config.json \
    --type=kubernetes.io/dockerconfigjson
```

The first case creates a secret detailed here: https://github.com/elotl/kip/issues/96
The second case creates a secret with the entire contents of /home/myuser/.docker/config.json base64 encoded.  For that case, the docker server can either be a hostname (e.g. `689494258501.dkr.ecr.us-east-1.amazonaws.com`) or a full url (`https://index.docker.io/v1/`).

This PR tries to understand both formats do work to extract the correct server credentials, either from the username and password fields or falling back to the auth field.  It's possible we could just use the auth field...  I'm unsure if we should be defensive or make that simplification.