### PR TITLE
Handle broken metadata response in google cloud

### DIFF
--- a/pkg/server/cloud/gce/metadata_test.go
+++ b/pkg/server/cloud/gce/metadata_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 Elotl Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test(t *testing.T) {
+	tests := []struct {
+		s     string
+		zone  string
+		isErr bool
+	}{
+		{
+			s:    "projects/832569367454/zones/us-west1-a",
+			zone: "us-west1-a",
+		},
+		{
+			s:    "projects/832569367454/zones/us-west1-a/",
+			zone: "us-west1-a",
+		},
+		{
+			s:     "",
+			isErr: true,
+		},
+	}
+	for _, tc := range tests {
+		resp, err := extractZoneFromResponse(tc.s)
+		if tc.isErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, tc.zone, resp)
+		}
+	}
+}

--- a/pkg/server/cloud/gce/network.go
+++ b/pkg/server/cloud/gce/network.go
@@ -108,7 +108,7 @@ func (c *gceClient) autodetectRegionAndZone() (string, string, error) {
 	}
 
 	md := newMetadataClient()
-	zone, err := md.Zone()
+	zone, err := getZoneFromMetadata(md)
 	if err != nil {
 		return "", "", util.WrapError(err, "error getting zone from GCE metadata service")
 	}


### PR DESCRIPTION
For some reason, when you curl the gce metadata service for the zone, from alpine, an extra slash gets added to the response:

```bash
exec -it curler -- /bin/ash
# curl "http://metadata.google.internal/computeMetadata/v1/instance/zone" -H "Metadata-Flavor: Google"
projects/832569367454/zones/us-west1-a/
```

This does not happen in other distros (debian and ubuntu were tested)
```
kk exec -it curler -- curl "http://metadata.google.internal/computeMetadata/v1/instance/zone" -H "Metadata-Flavor: Google"
projects/832569367454/zones/us-west1-a
```

The library we use assumes the response doesn't end with a slash and it'll break if it does end in a slash.  This PR gets the zone from the metadata ourselves and handle both cases.