### PR TITLE
provider.yaml flag to force cells to never have a public IP

### DIFF
--- a/docs/provider-config.md
+++ b/docs/provider-config.md
@@ -140,6 +140,13 @@ cells:
   # extraSecurityGroups:
   #   - sg-246810
 
+  # By default, cells will be assigned a publicIP address if the
+  # subnet is configured to allow access to the public internet
+  # without NAT.  Set privateIPOnly to true to force all cells
+  # to only have a private IP address.
+
+  # privateIPOnly: false
+
   # itzo configures the version of the itzo agent to use and where
   # itzo will be downloaded from.  You should only customize this if
   # you have built your own itzo agent or you would like to pin your

--- a/pkg/server/cloud/aws/aws_functional_test.go
+++ b/pkg/server/cloud/aws/aws_functional_test.go
@@ -41,7 +41,12 @@ func getEC2(t *testing.T, controllerID string) *AwsEC2 {
 	if !util.AWSEnvVarsSet() {
 		t.Fatal("Neet to setup AWS env vars for tests")
 	}
-	e, err := NewEC2Client(controllerID, controllerID, vpcID, defaultSubnetID, "")
+	e, err := NewEC2Client(EC2ClientConfig{
+		ControllerID: controllerID,
+		Nametag:      controllerID,
+		VPCID:        vpcID,
+		SubnetID:     defaultSubnetID,
+	})
 	if err != nil {
 		msg := "Error getting EC2 Client: " + err.Error()
 		assert.FailNow(t, msg)
@@ -73,11 +78,12 @@ func TestAWSCloud(t *testing.T) {
 		t.Fatal("Neet to setup AWS env vars for tests")
 	}
 	controllerID := api.SimpleNameGenerator.GenerateName(testControllerID)
-	//subnetID := maybeSetSubnet()
-	// While we're running 2 builds in different vpcs, just use the default
-	// subnet
-	subnetID := defaultSubnetID
-	c, err := NewEC2Client(controllerID, controllerID, vpcID, subnetID, "")
+	c, err := NewEC2Client(EC2ClientConfig{
+		ControllerID: controllerID,
+		Nametag:      controllerID,
+		VPCID:        vpcID,
+		SubnetID:     defaultSubnetID,
+	})
 	assert.Nil(t, err)
 	ts, err := functional.SetupCloudFunctionalTest(t, c, imageAmi, rootDevice, instanceType)
 	if err != nil {

--- a/pkg/server/cloud/gce/network.go
+++ b/pkg/server/cloud/gce/network.go
@@ -224,8 +224,9 @@ func (c *gceClient) GetDNSInfo() ([]string, []string, error) {
 	//
 	// This is fairly symplistic, might need to look into determining
 	// if the users environment has other settings
-	zoneLetter := c.zone[len(c.zone)-1]
-	s := fmt.Sprintf("%s.%s.internal.", string(zoneLetter), c.projectID)
+	// Note that the c. is not the zone letter. It does not change from
+	// zone to zone.
+	s := fmt.Sprintf("c.%s.internal.", c.projectID)
 	searches := []string{s, "google.internal."}
 	nameservers := []string{"169.254.169.254"}
 	return nameservers, searches, nil

--- a/pkg/server/cloud/gce/network.go
+++ b/pkg/server/cloud/gce/network.go
@@ -40,6 +40,8 @@ func (c *gceClient) ConnectWithPublicIPs() bool {
 	if !c.usePublicIPs {
 		return false
 	} else {
+		// Todo: need to fix this to ensure we are inside the
+		// same network
 		return !metadata.OnGCE()
 	}
 }

--- a/pkg/server/cloud/gce/option.go
+++ b/pkg/server/cloud/gce/option.go
@@ -52,6 +52,14 @@ func (w WithSubnetName) Apply(c *gceClient) error {
 	return nil
 }
 
+type WithPrivateIPOnly bool
+
+func (w WithPrivateIPOnly) Apply(c *gceClient) error {
+	privateIPOnly := bool(w)
+	c.usePublicIPs = !privateIPOnly
+	return nil
+}
+
 type WithCredentialsFile string
 
 func (w WithCredentialsFile) Apply(c *gceClient) error {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -140,11 +140,8 @@ type CellsConfig struct {
 	Nametag             string                        `json:"nametag"`
 	StatusInterval      int                           `json:"statusInterval"`
 	HealthCheck         HealthCheckConfig             `json:"healthcheck"`
-<<<<<<< HEAD
 	PrivateIPOnly       *bool                         `json:"privateIPOnly"`
-=======
 	CellConfig          map[string]string             `json:"cellConfig"`
->>>>>>> master
 }
 
 type HealthCheckConfig struct {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -271,6 +271,10 @@ func configureCloudProvider(cf *ServerConfigFile, controllerID, nametag string) 
 	if numClouds > 1 {
 		return nil, fmt.Errorf("Multiple clouds configured in cloud section of provider.yaml")
 	}
+	privateIPOnly := false
+	if cf.Cells.PrivateIPOnly != nil && *cf.Cells.PrivateIPOnly {
+		privateIPOnly = true
+	}
 	if cc.AWS != nil {
 		errs := validateAWSConfig(cc.AWS)
 		if len(errs) > 0 {
@@ -283,10 +287,6 @@ func configureCloudProvider(cf *ServerConfigFile, controllerID, nametag string) 
 			return nil, util.WrapError(err, "Could not configure AWS cloud client authorization")
 		}
 
-		privateIPOnly := false
-		if cf.Cells.PrivateIPOnly != nil && *cf.Cells.PrivateIPOnly {
-			privateIPOnly = true
-		}
 		// Gross: if vpc is "default", the NewEC2Client will
 		// attempt to figure out the VPCID and the actual ID
 		// will be available from there
@@ -336,6 +336,7 @@ func configureCloudProvider(cf *ServerConfigFile, controllerID, nametag string) 
 		options = append(options, gce.WithZone(cc.GCE.Zone))
 		options = append(options, gce.WithVPCName(cc.GCE.VPCName))
 		options = append(options, gce.WithSubnetName(cc.GCE.SubnetName))
+		options = append(options, gce.WithPrivateIPOnly(privateIPOnly))
 		if cc.GCE.CredentialsFile != "" {
 			options = append(options, gce.WithCredentialsFile(cc.GCE.CredentialsFile))
 		}


### PR DESCRIPTION
There are 2 changes in this one:

1. Refactor `NewEC2Client()` to take a config structure instead of an arguments list. I took that strategy from virtual-kubelet and like it because, for long argument lists, there's less chance you're going to pass in the wrong arg in the wrong place. You can also leave things empty if you want them to remain unspecified.

2. A new provider.yaml option that allows the user to turn off using public IP addresses for the entire controller.  I think this will be the default setting for most production systems.  I made it a pointer value so we can determine if the user left the value unspecified vs. setting it to false.  We can eventually decide what the default/unspecified value should be.

I also added a minor fix to the DNS configuration in GCE. The search path should be `c.<project_id>.internal.`.  The 'c' is NOT the zone: https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names