### PR TITLE
Add cells.cellConfig

### DIFF
--- a/deploy/terraform-gcp/main.tf
+++ b/deploy/terraform-gcp/main.tf
@@ -121,6 +121,10 @@ resource "null_resource" "kubeconfig" {
     EOF
   }
 
+  triggers = {
+    cluster_instance_ids = google_container_cluster.cluster.id
+  }
+
   depends_on = [
     google_container_cluster.cluster
   ]
@@ -137,6 +141,10 @@ resource "null_resource" "client_permissions" {
       KUBECONFIG = "${path.module}/kubeconfig"
     }
     command = "kubectl apply -f cluster-admin.yaml --username=client --password=${local.password}"
+  }
+
+  triggers = {
+    cluster_instance_ids = google_container_cluster.cluster.id
   }
 
   depends_on = [
@@ -159,6 +167,10 @@ resource "null_resource" "deploy" {
     ]
     # This needs kubectl >= 1.14.
     command = "kubectl apply -k ${var.kustomize-dir}"
+  }
+
+  triggers = {
+    cluster_instance_ids = google_container_cluster.cluster.id
   }
 
   depends_on = [

--- a/docs/provider-config.md
+++ b/docs/provider-config.md
@@ -181,4 +181,11 @@ cells:
   #     healthyTimeout: 180
   #     # interval between checks must be >= 10, default is 60
   #     interval: 60
+
+  # CellConfig can be used to send a map of key/value pairs to cells. It is
+  # used to configure the image cache right now.
+  # cellConfig:
+  #   imageCacheEndpoint: 10.20.0.2:/data
+  #   imageCacheMountDir: /var/cache/images
+  #   imageCacheMountOpts: -o ro
 ```

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -140,6 +140,7 @@ type CellsConfig struct {
 	Nametag             string                        `json:"nametag"`
 	StatusInterval      int                           `json:"statusInterval"`
 	HealthCheck         HealthCheckConfig             `json:"healthcheck"`
+	CellConfig          map[string]string             `json:"cellConfig"`
 }
 
 type HealthCheckConfig struct {

--- a/pkg/server/nodemanager/node_controller.go
+++ b/pkg/server/nodemanager/node_controller.go
@@ -64,6 +64,7 @@ type NodeControllerConfig struct {
 	ReaperInterval    time.Duration
 	ItzoVersion       string
 	ItzoURL           string
+	CellConfig        map[string]string
 }
 
 type NodeController struct {
@@ -208,6 +209,9 @@ func (c *NodeController) getInstanceCloudInit() error {
 		string(keyBytes), path.Join(itzoDir, "server.key"), "0600")
 	c.CloudInitFile.AddItzoVersion(c.Config.ItzoVersion)
 	c.CloudInitFile.AddItzoURL(c.Config.ItzoURL)
+	if len(c.Config.CellConfig) > 0 {
+		c.CloudInitFile.AddCellConfig(c.Config.CellConfig)
+	}
 	return nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -358,6 +358,7 @@ func NewInstanceProvider(configFilePath, nodeName, internalIP, serverURL, networ
 			ReaperInterval:    10 * time.Second,
 			ItzoVersion:       serverConfigFile.Cells.Itzo.Version,
 			ItzoURL:           serverConfigFile.Cells.Itzo.URL,
+			CellConfig:        serverConfigFile.Cells.CellConfig,
 		},
 		NodeRegistry:  nodeRegistry,
 		LogRegistry:   logRegistry,

--- a/pkg/util/cloudinitfile/cloudinitfile.go
+++ b/pkg/util/cloudinitfile/cloudinitfile.go
@@ -37,6 +37,7 @@ var (
 	itzoDir          = "/tmp/itzo"
 	ItzoVersionPath  = itzoDir + "/itzo_version"
 	ItzoURLPath      = itzoDir + "/itzo_url"
+	CellConfigPath   = itzoDir + "/cell_config.yaml"
 	cloudInitHeader  = []byte("#cloud-config\n")
 	maxCloudInitSize = 16000
 	semverRegex      = regexp.MustCompile("^" + semverRegexFmt + "$")
@@ -104,6 +105,17 @@ func (f *File) AddItzoURL(url string) {
 		return
 	}
 	f.AddKipFile(url, ItzoURLPath, "0444")
+}
+
+func (f *File) AddCellConfig(cfg map[string]string) {
+	if len(cfg) == 0 {
+		return
+	}
+	buf, err := yaml.Marshal(cfg)
+	if err != nil {
+		return
+	}
+	f.AddKipFile(string(buf), CellConfigPath, "0444")
 }
 
 func (f *File) Contents() ([]byte, error) {


### PR DESCRIPTION
Two changes:
- A new config file parameter, `cells.cellConfig`. This is a map[string]string, and it will be serialized and sent to the instance via as a cloud-init file `/tmp/itzo/cell_config.yaml`. Agents on the instance can read it in, and get configuration data from the entries. Right now it's used for providing image-cache configuration parameters.
- A small fix to ensure manifests are re-deployed in terraform-gcp when the cluster ID changes.