### PR TITLE
Update stats

### DIFF
--- a/deploy/manifests/virtual-kubelet/base/deployment.yaml
+++ b/deploy/manifests/virtual-kubelet/base/deployment.yaml
@@ -69,6 +69,7 @@ spec:
         - --disable-taint
         - --klog.logtostderr
         - --klog.v=2
+        - --metrics-addr=:10255
         image: elotl/virtual-kubelet:latest
         imagePullPolicy: Always
         name: virtual-kubelet
@@ -103,10 +104,29 @@ spec:
           readOnly: true
         securityContext:
           privileged: true
+      - command:
+        - /bin/sh
+        - -c
+        - exec kube-proxy --oom-score-adj=-998 --bind-address=127.0.0.1 --v=2
+        image: k8s.gcr.io/kube-proxy:v1.18.3
+        imagePullPolicy: IfNotPresent
+        name: kube-proxy
+        resources:
+          requests:
+            cpu: 100m
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       serviceAccountName: virtual-kubelet
-      hostNetwork: true
       tolerations:
       - key: "node-role.kubernetes.io/master"
         effect: "NoSchedule"
@@ -123,7 +143,7 @@ spec:
             mode: 0600
       - name: xtables-lock
         hostPath:
-          path: /run/xtables.lock
+          path: /run/virtual-kubelet-xtables.lock
           type: FileOrCreate
       - name: lib-modules
         hostPath:

--- a/deploy/manifests/virtual-kubelet/base/sa.yaml
+++ b/deploy/manifests/virtual-kubelet/base/sa.yaml
@@ -105,6 +105,8 @@ rules:
       - endpoints
     verbs:
       - get
+      - list
+      - watch
   - apiGroups:
     - certificates.k8s.io
     resourceNames:

--- a/pkg/server/getstatssummary_test.go
+++ b/pkg/server/getstatssummary_test.go
@@ -17,10 +17,9 @@ limitations under the License.
 package server
 
 import (
+	"fmt"
 	"testing"
-	"time"
 
-	"github.com/elotl/kip/pkg/api"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
@@ -31,307 +30,308 @@ func makeUint64Ptr(i int) *uint64 {
 	return &ret
 }
 
-//func getContainerStats(startTime metav1.Time, podMetrics *api.Metrics, units []api.Unit) (usageMetrics, []stats.ContainerStats)
-func TestGetContainerStats(t *testing.T) {
+//func float64ToUint64Ptr(f float64, exists bool) *uint64
+func TestFloat64ToUint64Ptr(t *testing.T) {
 	testCases := []struct {
-		start          metav1.Time
-		timestamp      metav1.Time
-		sampleTimeDiff time.Duration
-		podMetrics     []*api.Metrics
-		units          []api.Unit
-		podUsage       usageMetrics
-		containerStats []stats.ContainerStats
+		f      float64
+		exists bool
+		result *uint64
 	}{
 		{
-			// Two units.
-			start:          metav1.NewTime(time.Now().Add(-5 * time.Minute)),
-			timestamp:      metav1.NewTime(time.Now()),
-			sampleTimeDiff: 10000 * time.Nanosecond,
-			podMetrics: []*api.Metrics{
-				{
-					ResourceUsage: api.ResourceMetrics{
-						"unit1.cpuUsage":         120,
-						"unit1.memoryUsage":      789,
-						"unit1.memoryWorkingSet": 456,
-						"unit1.memoryAvailable":  1<<62 + 1,
-						"unit1.memoryRSS":        88,
-						"unit2.cpuUsage":         100,
-						"unit2.memoryUsage":      222,
-						"unit2.memoryWorkingSet": 333,
-						"unit2.memoryAvailable":  999,
-						"unit2.memoryRSS":        88,
-					},
-				},
-				{
-					ResourceUsage: api.ResourceMetrics{
-						"unit1.cpuUsage":         123,
-						"unit1.memoryUsage":      789,
-						"unit1.memoryWorkingSet": 456,
-						"unit1.memoryAvailable":  888,
-						"unit1.memoryRSS":        88,
-						"unit2.cpuUsage":         111,
-						"unit2.memoryUsage":      222,
-						"unit2.memoryWorkingSet": 333,
-						"unit2.memoryAvailable":  999,
-						"unit2.memoryRSS":        88,
-					},
-				},
-			},
-			units: []api.Unit{
-				{
-					Name: "unit1",
-				},
-				{
-					Name: "unit2",
-				},
-			},
-			podUsage: usageMetrics{
-				UsageCoreNanoSeconds: 123 + 111,
-				UsageNanoCores:       1400000,
-				AvailableBytes:       888 + 999,
-				UsageBytes:           789 + 222,
-				WorkingSetBytes:      456 + 333,
-				RSSBytes:             88 + 88,
-			},
-			containerStats: []stats.ContainerStats{
-				{
-					Name: "unit1",
-					CPU: &stats.CPUStats{
-						UsageCoreNanoSeconds: makeUint64Ptr(123),
-						UsageNanoCores:       makeUint64Ptr(300000),
-					},
-					Memory: &stats.MemoryStats{
-						UsageBytes:      makeUint64Ptr(789),
-						WorkingSetBytes: makeUint64Ptr(456),
-						RSSBytes:        makeUint64Ptr(88),
-						AvailableBytes:  makeUint64Ptr(888),
-					},
-				},
-				{
-					Name: "unit2",
-					CPU: &stats.CPUStats{
-						UsageCoreNanoSeconds: makeUint64Ptr(111),
-						UsageNanoCores:       makeUint64Ptr(1100000),
-					},
-					Memory: &stats.MemoryStats{
-						UsageBytes:      makeUint64Ptr(222),
-						WorkingSetBytes: makeUint64Ptr(333),
-						RSSBytes:        makeUint64Ptr(88),
-						AvailableBytes:  makeUint64Ptr(999),
-					},
-				},
-			},
+			f:      1.0,
+			exists: true,
+			result: makeUint64Ptr(1),
 		},
 		{
-			// Two units, only one has reported metrics.
-			start:          metav1.NewTime(time.Now().Add(-2 * time.Minute)),
-			timestamp:      metav1.NewTime(time.Now()),
-			sampleTimeDiff: 5000 * time.Nanosecond,
-			podMetrics: []*api.Metrics{
-				{
-					ResourceUsage: api.ResourceMetrics{
-						"unit1.cpuUsage":         12345,
-						"unit1.memoryUsage":      67890,
-						"unit1.memoryWorkingSet": 66666,
-					},
-				},
-				{
-					ResourceUsage: api.ResourceMetrics{
-						"unit1.cpuUsage":         12345,
-						"unit1.memoryUsage":      67890,
-						"unit1.memoryWorkingSet": 66666,
-					},
-				},
-			},
-			units: []api.Unit{
-				{
-					Name: "unit1",
-				},
-				{
-					Name: "unit2",
-				},
-			},
-			podUsage: usageMetrics{
-				UsageCoreNanoSeconds: 12345,
-				UsageBytes:           67890,
-				WorkingSetBytes:      66666,
-			},
-			containerStats: []stats.ContainerStats{
-				{
-					Name: "unit1",
-					CPU: &stats.CPUStats{
-						UsageCoreNanoSeconds: makeUint64Ptr(12345),
-					},
-					Memory: &stats.MemoryStats{
-						UsageBytes:      makeUint64Ptr(67890),
-						WorkingSetBytes: makeUint64Ptr(66666),
-					},
-				},
-				{
-					Name:   "unit2",
-					CPU:    &stats.CPUStats{},
-					Memory: &stats.MemoryStats{},
-				},
-			},
+			f:      0.0,
+			exists: true,
+			result: makeUint64Ptr(0),
 		},
 		{
-			// One unit, spurious CPU sample (timestamp decreased).
-			start:          metav1.NewTime(time.Now().Add(-2 * time.Minute)),
-			timestamp:      metav1.NewTime(time.Now()),
-			sampleTimeDiff: -1 * time.Nanosecond,
-			podMetrics: []*api.Metrics{
-				{
-					ResourceUsage: api.ResourceMetrics{
-						"unit1.cpuUsage":         12345,
-						"unit1.memoryUsage":      22222,
-						"unit1.memoryWorkingSet": 11111,
-					},
-				},
-				{
-					ResourceUsage: api.ResourceMetrics{
-						"unit1.cpuUsage":         12346,
-						"unit1.memoryUsage":      22222,
-						"unit1.memoryWorkingSet": 11111,
-					},
-				},
-			},
-			units: []api.Unit{
-				{
-					Name: "unit1",
-				},
-			},
-			podUsage: usageMetrics{
-				UsageCoreNanoSeconds: 12346,
-				UsageBytes:           22222,
-				WorkingSetBytes:      11111,
-			},
-			containerStats: []stats.ContainerStats{
-				{
-					Name: "unit1",
-					CPU: &stats.CPUStats{
-						UsageCoreNanoSeconds: makeUint64Ptr(12346),
-					},
-					Memory: &stats.MemoryStats{
-						UsageBytes:      makeUint64Ptr(22222),
-						WorkingSetBytes: makeUint64Ptr(11111),
-					},
-				},
-			},
-		},
-		{
-			// Pod disk metrics.
-			start:          metav1.NewTime(time.Now().Add(-2 * time.Minute)),
-			timestamp:      metav1.NewTime(time.Now()),
-			sampleTimeDiff: -1 * time.Nanosecond,
-			podMetrics: []*api.Metrics{
-				{
-					ResourceUsage: api.ResourceMetrics{
-						"fsAvailable":  11111,
-						"fsUsed":       22222,
-						"fsCapacity":   33333,
-						"fsInodes":     99999,
-						"fsInodesFree": 44444,
-						"fsInodesUsed": 55555,
-					},
-				},
-				{
-					ResourceUsage: api.ResourceMetrics{
-						"fsAvailable":  11111,
-						"fsUsed":       22222,
-						"fsCapacity":   33333,
-						"fsInodes":     99999,
-						"fsInodesFree": 44444,
-						"fsInodesUsed": 55555,
-					},
-				},
-			},
-			units: []api.Unit{
-				{
-					Name: "unit1",
-				},
-			},
-			podUsage: usageMetrics{
-				FSAvailableBytes: 11111,
-				FSUsedBytes:      22222,
-				FSCapacityBytes:  33333,
-				FSInodes:         99999,
-				FSInodesFree:     44444,
-				FSInodesUsed:     55555,
-			},
-			containerStats: []stats.ContainerStats{
-				{
-					Name:   "unit1",
-					CPU:    &stats.CPUStats{},
-					Memory: &stats.MemoryStats{},
-				},
-			},
-		},
-		{
-			// Pod network metrics.
-			start:          metav1.NewTime(time.Now().Add(-2 * time.Minute)),
-			timestamp:      metav1.NewTime(time.Now()),
-			sampleTimeDiff: -1 * time.Nanosecond,
-			podMetrics: []*api.Metrics{
-				{
-					ResourceUsage: api.ResourceMetrics{
-						"netRx":       11111,
-						"netRxErrors": 1,
-						"netTx":       33333,
-						"netTxErrors": 3,
-					},
-				},
-				{
-					ResourceUsage: api.ResourceMetrics{
-						"netRx":       11111,
-						"netRxErrors": 1,
-						"netTx":       33333,
-						"netTxErrors": 3,
-					},
-				},
-			},
-			units: []api.Unit{
-				{
-					Name: "unit1",
-				},
-			},
-			podUsage: usageMetrics{
-				NetRxBytes:  11111,
-				NetRxErrors: 1,
-				NetTxBytes:  33333,
-				NetTxErrors: 3,
-			},
-			containerStats: []stats.ContainerStats{
-				{
-					Name:   "unit1",
-					CPU:    &stats.CPUStats{},
-					Memory: &stats.MemoryStats{},
-				},
-			},
+			f:      0.0,
+			exists: false,
+			result: nil,
 		},
 	}
 	for _, tc := range testCases {
-		tc.podMetrics[1].Timestamp = api.Time{
-			Time: tc.timestamp.Time,
-		}
-		tc.podMetrics[0].Timestamp = api.Time{
-			Time: tc.timestamp.Add(-tc.sampleTimeDiff),
-		}
-		for i, _ := range tc.containerStats {
-			tc.containerStats[i].StartTime = tc.start
-			tc.containerStats[i].CPU.Time = tc.timestamp
-			tc.containerStats[i].Memory.Time = tc.timestamp
-		}
-		podUsage, containerStats := getStats(tc.start, tc.podMetrics, tc.units)
-		assert.Equal(t, tc.podUsage, podUsage)
-		assert.Equal(t, tc.containerStats, containerStats)
-		for _, cstat := range tc.containerStats {
-			assert.Equal(t, tc.start, cstat.StartTime)
-			if cstat.CPU != nil {
-				assert.Equal(t, tc.timestamp, cstat.CPU.Time)
-			}
-			if cstat.Memory != nil {
-				assert.Equal(t, tc.timestamp, cstat.Memory.Time)
-			}
-		}
+		result := float64ToUint64Ptr(tc.f, tc.exists)
+		assert.Equal(t, tc.result, result)
+	}
+}
+
+//func addToUint64Ptr(orig, add *uint64) *uint64
+func TestAddToUint64Ptr(t *testing.T) {
+	testCases := []struct {
+		orig   *uint64
+		add    *uint64
+		result *uint64
+	}{
+		{
+			orig:   makeUint64Ptr(1),
+			add:    makeUint64Ptr(2),
+			result: makeUint64Ptr(3),
+		},
+		{
+			orig:   nil,
+			add:    makeUint64Ptr(2),
+			result: makeUint64Ptr(2),
+		},
+		{
+			orig:   makeUint64Ptr(3),
+			add:    nil,
+			result: makeUint64Ptr(3),
+		},
+		{
+			orig:   nil,
+			add:    nil,
+			result: nil,
+		},
+	}
+	for _, tc := range testCases {
+		result := addToUint64Ptr(tc.orig, tc.add)
+		assert.Equal(t, tc.result, result)
+	}
+}
+
+//func ensurePodCPUStats(ps *stats.PodStats, timestamp metav1.Time)
+func TestEnsurePodCPUStats(t *testing.T) {
+	ts := metav1.Now()
+	ps := stats.PodStats{}
+	ensurePodCPUStats(&ps, ts)
+	assert.NotNil(t, ps.CPU)
+	assert.Equal(t, ts, ps.CPU.Time)
+	ensurePodCPUStats(&ps, ts)
+	assert.NotNil(t, ps.CPU)
+	assert.Equal(t, ts, ps.CPU.Time)
+}
+
+//func ensurePodMemoryStats(ps *stats.PodStats, timestamp metav1.Time)
+func TestEnsurePodMemoryStats(t *testing.T) {
+	ts := metav1.Now()
+	ps := stats.PodStats{}
+	ensurePodMemoryStats(&ps, ts)
+	assert.NotNil(t, ps.Memory)
+	assert.Equal(t, ts, ps.Memory.Time)
+	ensurePodMemoryStats(&ps, ts)
+	assert.NotNil(t, ps.Memory)
+	assert.Equal(t, ts, ps.Memory.Time)
+}
+
+//func ensurePodNetworkStats(ps stats.PodStats, timestamp metav1.Time)
+func TestEnsurePodNetworkStats(t *testing.T) {
+	ts := metav1.Now()
+	ps := stats.PodStats{}
+	ensurePodNetworkStats(&ps, ts)
+	assert.NotNil(t, ps.Network)
+	assert.Equal(t, ts, ps.Network.Time)
+	assert.Len(t, ps.Network.Interfaces, 1)
+	ensurePodNetworkStats(&ps, ts)
+	assert.NotNil(t, ps.Network)
+	assert.Equal(t, ts, ps.Network.Time)
+	assert.Len(t, ps.Network.Interfaces, 1)
+}
+
+//func ensurePodVolumeStats(ps stats.PodStats, timestamp metav1.Time)
+func TestEnsurePodVolumeStats(t *testing.T) {
+	ts := metav1.Now()
+	ps := stats.PodStats{}
+	ensurePodVolumeStats(&ps, ts)
+	assert.Len(t, ps.VolumeStats, 1)
+	assert.Equal(t, ts, ps.VolumeStats[0].FsStats.Time)
+	ensurePodVolumeStats(&ps, ts)
+	assert.Len(t, ps.VolumeStats, 1)
+	assert.Equal(t, ts, ps.VolumeStats[0].FsStats.Time)
+}
+
+//func ensureContainerCPUStats(cstats stats.ContainerStats, timestamp metav1.Time)
+func TestEnsureContainerCPUStats(t *testing.T) {
+	ts := metav1.Now()
+	cs := stats.ContainerStats{}
+	ensureContainerCPUStats(&cs, ts)
+	assert.NotNil(t, cs.CPU)
+	assert.Equal(t, ts, cs.CPU.Time)
+	ensureContainerCPUStats(&cs, ts)
+	assert.NotNil(t, cs.CPU)
+	assert.Equal(t, ts, cs.CPU.Time)
+}
+
+//func ensureContainerMemoryStats(cstats stats.ContainerStats, timestamp metav1.Time)
+func TestEnsureContainerMemoryStats(t *testing.T) {
+	ts := metav1.Now()
+	cs := stats.ContainerStats{}
+	ensureContainerMemoryStats(&cs, ts)
+	assert.NotNil(t, cs.Memory)
+	assert.Equal(t, ts, cs.Memory.Time)
+	ensureContainerMemoryStats(&cs, ts)
+	assert.NotNil(t, cs.Memory)
+	assert.Equal(t, ts, cs.Memory.Time)
+}
+
+//func updatePodCPUStats(ps stats.PodStats, cstats stats.ContainerStats, timestamp metav1.Time)
+func TestUpdatePodCPUStats(t *testing.T) {
+	ts := metav1.Now()
+	cs := stats.ContainerStats{
+		CPU: &stats.CPUStats{
+			UsageCoreNanoSeconds: makeUint64Ptr(9999),
+			UsageNanoCores:       makeUint64Ptr(1234),
+		},
+	}
+	ps := stats.PodStats{}
+	updatePodCPUStats(&ps, &cs, ts)
+	assert.NotNil(t, ps.CPU)
+	assert.Equal(t, makeUint64Ptr(9999), ps.CPU.UsageCoreNanoSeconds)
+	assert.Equal(t, makeUint64Ptr(1234), ps.CPU.UsageNanoCores)
+	cs = stats.ContainerStats{
+		CPU: &stats.CPUStats{
+			UsageCoreNanoSeconds: makeUint64Ptr(1000),
+			UsageNanoCores:       makeUint64Ptr(3000),
+		},
+	}
+	updatePodCPUStats(&ps, &cs, ts)
+	assert.NotNil(t, ps.CPU)
+	assert.Equal(t, makeUint64Ptr(10999), ps.CPU.UsageCoreNanoSeconds)
+	assert.Equal(t, makeUint64Ptr(4234), ps.CPU.UsageNanoCores)
+}
+
+//func updatePodMemoryStats(ps stats.PodStats, cstats stats.ContainerStats, timestamp metav1.Time)
+func TestUpdatePodMemoryStats(t *testing.T) {
+	ts := metav1.Now()
+	cs := stats.ContainerStats{
+		Memory: &stats.MemoryStats{
+			AvailableBytes:  makeUint64Ptr(1),
+			MajorPageFaults: makeUint64Ptr(2),
+			PageFaults:      makeUint64Ptr(3),
+			RSSBytes:        makeUint64Ptr(4),
+			UsageBytes:      makeUint64Ptr(5),
+			WorkingSetBytes: makeUint64Ptr(6),
+		},
+	}
+	ps := stats.PodStats{}
+	updatePodMemoryStats(&ps, &cs, ts)
+	assert.NotNil(t, ps.Memory)
+	assert.Equal(t, makeUint64Ptr(1), ps.Memory.AvailableBytes)
+	assert.Equal(t, makeUint64Ptr(2), ps.Memory.MajorPageFaults)
+	assert.Equal(t, makeUint64Ptr(3), ps.Memory.PageFaults)
+	assert.Equal(t, makeUint64Ptr(4), ps.Memory.RSSBytes)
+	assert.Equal(t, makeUint64Ptr(5), ps.Memory.UsageBytes)
+	assert.Equal(t, makeUint64Ptr(6), ps.Memory.WorkingSetBytes)
+	cs = stats.ContainerStats{
+		Memory: &stats.MemoryStats{
+			AvailableBytes:  makeUint64Ptr(11),
+			MajorPageFaults: makeUint64Ptr(22),
+			PageFaults:      makeUint64Ptr(33),
+			RSSBytes:        makeUint64Ptr(44),
+			UsageBytes:      makeUint64Ptr(55),
+			WorkingSetBytes: makeUint64Ptr(66),
+		},
+	}
+	updatePodMemoryStats(&ps, &cs, ts)
+	assert.NotNil(t, ps.Memory)
+	assert.Equal(t, makeUint64Ptr(12), ps.Memory.AvailableBytes)
+	assert.Equal(t, makeUint64Ptr(24), ps.Memory.MajorPageFaults)
+	assert.Equal(t, makeUint64Ptr(36), ps.Memory.PageFaults)
+	assert.Equal(t, makeUint64Ptr(48), ps.Memory.RSSBytes)
+	assert.Equal(t, makeUint64Ptr(60), ps.Memory.UsageBytes)
+	assert.Equal(t, makeUint64Ptr(72), ps.Memory.WorkingSetBytes)
+}
+
+//func updatePodNetworkStats(ps stats.PodStats, timestamp metav1.Time, k string, v uint64)
+func TestUpdatePodNetworkStats(t *testing.T) {
+	ts := metav1.Now()
+	ps := stats.PodStats{}
+	updatePodNetworkStats(&ps, ts, "netRx", 123)
+	updatePodNetworkStats(&ps, ts, "netRxErrors", 10)
+	updatePodNetworkStats(&ps, ts, "netTx", 456)
+	updatePodNetworkStats(&ps, ts, "netTxErrors", 20)
+	assert.NotNil(t, ps.Network)
+	assert.Equal(t, makeUint64Ptr(123), ps.Network.InterfaceStats.RxBytes)
+	assert.Equal(t, makeUint64Ptr(10), ps.Network.InterfaceStats.RxErrors)
+	assert.Equal(t, makeUint64Ptr(456), ps.Network.InterfaceStats.TxBytes)
+	assert.Equal(t, makeUint64Ptr(20), ps.Network.InterfaceStats.TxErrors)
+}
+
+//func updatePodVolumeStats(ps stats.PodStats, timestamp metav1.Time, k string, v uint64)
+func TestUpdatePodVolumeStats(t *testing.T) {
+	ts := metav1.Now()
+	ps := stats.PodStats{}
+	updatePodVolumeStats(&ps, ts, "fsAvailable", 11)
+	updatePodVolumeStats(&ps, ts, "fsCapacity", 22)
+	updatePodVolumeStats(&ps, ts, "fsUsed", 33)
+	updatePodVolumeStats(&ps, ts, "fsInodesFree", 44)
+	updatePodVolumeStats(&ps, ts, "fsInodes", 55)
+	updatePodVolumeStats(&ps, ts, "fsInodesUsed", 66)
+	assert.Len(t, ps.VolumeStats, 1)
+	assert.Equal(t, makeUint64Ptr(11), ps.VolumeStats[0].AvailableBytes)
+	assert.Equal(t, makeUint64Ptr(22), ps.VolumeStats[0].CapacityBytes)
+	assert.Equal(t, makeUint64Ptr(33), ps.VolumeStats[0].UsedBytes)
+	assert.Equal(t, makeUint64Ptr(44), ps.VolumeStats[0].InodesFree)
+	assert.Equal(t, makeUint64Ptr(55), ps.VolumeStats[0].Inodes)
+	assert.Equal(t, makeUint64Ptr(66), ps.VolumeStats[0].InodesUsed)
+}
+
+//func updateContainerMemoryStats(cstats stats.ContainerStats, timestamp metav1.Time, k string, value uint64)
+func TestUpdateContainerMemoryStats(t *testing.T) {
+	ts := metav1.Now()
+	cs := stats.ContainerStats{}
+	updateContainerMemoryStats(&cs, ts, "memoryAvailable", 111)
+	updateContainerMemoryStats(&cs, ts, "memoryMajorPageFaults", 222)
+	updateContainerMemoryStats(&cs, ts, "memoryPageFaults", 333)
+	updateContainerMemoryStats(&cs, ts, "memoryRSS", 444)
+	updateContainerMemoryStats(&cs, ts, "memoryUsage", 555)
+	updateContainerMemoryStats(&cs, ts, "memoryWorkingSet", 666)
+	assert.NotNil(t, cs.Memory)
+	assert.Equal(t, makeUint64Ptr(111), cs.Memory.AvailableBytes)
+	assert.Equal(t, makeUint64Ptr(222), cs.Memory.MajorPageFaults)
+	assert.Equal(t, makeUint64Ptr(333), cs.Memory.PageFaults)
+	assert.Equal(t, makeUint64Ptr(444), cs.Memory.RSSBytes)
+	assert.Equal(t, makeUint64Ptr(555), cs.Memory.UsageBytes)
+	assert.Equal(t, makeUint64Ptr(666), cs.Memory.WorkingSetBytes)
+}
+
+//func updateContainerCPUStats(cstats stats.ContainerStats, timestamp metav1.Time, k string, value uint64, prevValue *uint64, nanoseconds int64)
+func TestUpdateContainerCPUStats(t *testing.T) {
+	testCases := []struct {
+		value          uint64
+		prevValue      *uint64
+		nanoseconds    int64
+		usageNanoCores *uint64
+	}{
+		{
+			// Basic case.
+			value:          1234,
+			prevValue:      makeUint64Ptr(333),
+			nanoseconds:    10000000,
+			usageNanoCores: makeUint64Ptr(90100),
+		},
+		{
+			// Time difference between samples is negative.
+			value:          1234,
+			prevValue:      makeUint64Ptr(333),
+			nanoseconds:    -1000,
+			usageNanoCores: nil,
+		},
+		{
+			// No previous sample.
+			value:          1234,
+			prevValue:      nil,
+			nanoseconds:    1000,
+			usageNanoCores: nil,
+		},
+		{
+			// Negative CPU usage diff.
+			value:          1234,
+			prevValue:      makeUint64Ptr(2000),
+			nanoseconds:    1000,
+			usageNanoCores: nil,
+		},
+	}
+	for i, tc := range testCases {
+		ts := metav1.Now()
+		cs := stats.ContainerStats{}
+		msg := fmt.Sprintf("test case #%d %+v failed", i+1, tc)
+		updateContainerCPUStats(&cs, ts, "cpuUsage", tc.value, tc.prevValue, tc.nanoseconds)
+		assert.NotNil(t, cs.CPU)
+		assert.Equal(t, makeUint64Ptr(int(tc.value)), cs.CPU.UsageCoreNanoSeconds)
+		assert.Equal(t, tc.usageNanoCores, cs.CPU.UsageNanoCores, msg)
 	}
 }

--- a/scripts/init-cert/csr/create-csr.sh
+++ b/scripts/init-cert/csr/create-csr.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -xeuo pipefail
 
-export NODE_NAME=${NODE_NAME:-virtual-kubelet}
 export CSR_NAME=${CSR_NAME:-$NODE_NAME-$(date +%s)}
-export INTERNAL_IP=$(ip route get 8.8.8.8 | grep src | head -n1 | awk '{print $7}')
 
 rm -f $NODE_NAME.key $NODE_NAME.csr $NODE_NAME.crt
 

--- a/scripts/run_smoke_test.sh
+++ b/scripts/run_smoke_test.sh
@@ -19,7 +19,9 @@ export KUBECONFIG=$(mktemp)
 cleanup() {
     kubectl get pods -A || true
     kubectl get nodes
-    kubectl logs -n kube-system -l app=virtual-kubelet --tail=-1 || true
+    kubectl -n kube-system describe pod -l app=virtual-kubelet || true
+    kubectl logs -n kube-system -l app=virtual-kubelet -c init-cert --tail=-1 || true
+    kubectl logs -n kube-system -l app=virtual-kubelet -c virtual-kubelet --tail=-1 || true
     kubectl delete pod nginx > /dev/null 2>&1 || true
     kubectl delete svc nginx > /dev/null 2>&1 || true
     kubectl delete pod test > /dev/null 2>&1 || true


### PR DESCRIPTION
This adds more metrics to the stats summary API, and makes Kip use the default metrics port by default. The default port is pretty much a requirement when using metrics-server; even though the port is configurable, it only is on a per-cluster (not per-node) basis. That is, if we want to collect metrics from nodes we have to choose one port all kubelet must use for the stats summary endpoint.

To fix this, I made Kip NOT use host network mode by default. I added kube-proxy in a sidecar for setting up NodePorts in the VK pod.

Since the IP address now will likely change after every pod restart, I also added a check to the init container when generating the certificate, so that the cert will be re-created if the IP has changed.

With these changes, the stats are a lot more detailed:

      {
         "containers" : [
            {
               "cpu" : {
                  "time" : "2020-05-26T22:09:42Z",
                  "usageCoreNanoSeconds" : 228726035073,
                  "usageNanoCores" : 258544883
               },
               "memory" : {
                  "majorPageFaults" : 53,
                  "rssBytes" : 7199850496,
                  "time" : "2020-05-26T22:09:42Z",
                  "usageBytes" : 8749936640,
                  "workingSetBytes" : 8109391872
               },
               "name" : "buildkite",
               "startTime" : "2020-05-26T22:00:57Z"
            }
         ],
         "cpu" : {
            "time" : "2020-05-26T22:09:42Z",
            "usageCoreNanoSeconds" : 228726035073,
            "usageNanoCores" : 258544883
         },
         "ephemeral-storage" : {
            "availableBytes" : 7408414720,
            "capacityBytes" : 10222866432,
            "inodes" : 1290240,
            "inodesFree" : 1165646,
            "inodesUsed" : 124594,
            "time" : "2020-05-26T22:09:42Z",
            "usedBytes" : 2797674496
         },
         "memory" : {
            "majorPageFaults" : 53,
            "rssBytes" : 7199850496,
            "time" : "2020-05-26T22:09:42Z",
            "usageBytes" : 8749936640,
            "workingSetBytes" : 8109391872
         },
         "network" : {
            "interfaces" : [
               {
                  "name" : "eth0",
                  "rxBytes" : 716386029,
                  "txBytes" : 8983003
               }
            ],
            "name" : "eth0",
            "rxBytes" : 716386029,
            "time" : "2020-05-26T22:09:42Z",
            "txBytes" : 8983003
         },
         "podRef" : {
            "name" : "android-ndk-f49b9496c-nlxsr",
            "namespace" : "default",
            "uid" : "1c6c2b41-9f9a-11ea-8636-42010a800163"
         },
         "startTime" : "2020-05-26T22:00:57Z"
    }

The GKE monitoring dashboard also shows pod and container metrics from VK workloads:

![image](https://user-images.githubusercontent.com/456904/83057000-27bcf200-a00b-11ea-8ffe-be37e605312a.png)

![image](https://user-images.githubusercontent.com/456904/83055552-d7449500-a008-11ea-8a63-2eec882cb478.png)

Related itzo PR: https://github.com/elotl/itzo/pull/88