### PR TITLE
Bcox gke metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine
 
 RUN apk add --update bash ca-certificates iptables
 
-COPY virtual-kubelet /virtual-kubelet
-RUN chmod 755 /virtual-kubelet
 COPY kipctl /kipctl
 RUN chmod 755 /kipctl
+COPY virtual-kubelet /virtual-kubelet
+RUN chmod 755 /virtual-kubelet
 
 ENTRYPOINT ["/virtual-kubelet"]

--- a/pkg/server/cloud/gce/gce.go
+++ b/pkg/server/cloud/gce/gce.go
@@ -59,6 +59,7 @@ type gceClient struct {
 	usePublicIPs         bool
 	bootSecurityGroupIDs []string
 	cloudStatus          *cloud.AZSubnetStatus
+	gkeMetadata          map[string]string
 }
 
 func NewGCEClient(controllerID, nametag, projectID string, opts ...ClientOption) (*gceClient, error) {
@@ -117,11 +118,11 @@ func NewGCEClient(controllerID, nametag, projectID string, opts ...ClientOption)
 			return nil, err
 		}
 	}
-
 	client.cloudStatus, err = cloud.NewAZSubnetStatus(client)
 	if err != nil {
 		return nil, util.WrapError(err, "Error creating gce cloud status keeper")
 	}
+	client.gkeMetadata = getGKEMetadata()
 
 	return client, nil
 }

--- a/pkg/server/cloud/gce/network.go
+++ b/pkg/server/cloud/gce/network.go
@@ -31,7 +31,7 @@ import (
 func zoneToRegion(zone string) (string, error) {
 	parts := strings.Split(zone, "-")
 	if len(parts) != 3 {
-		return "", fmt.Errorf("unknown zone format, expecting geo-region-zone format")
+		return "", fmt.Errorf("unknown zone format, expecting geo-region-zone format got %q", zone)
 	}
 	return fmt.Sprintf("%s-%s", parts[0], parts[1]), nil
 }

--- a/pkg/server/cloud/gce/option.go
+++ b/pkg/server/cloud/gce/option.go
@@ -32,6 +32,9 @@ type ClientOption interface {
 type WithZone string
 
 func (w WithZone) Apply(c *gceClient) error {
+	if len(w) == 0 {
+		return nil
+	}
 	c.zone = string(w)
 	var err error
 	c.region, err = zoneToRegion(c.zone)


### PR DESCRIPTION
This adds the following GKE instance metadata keys present on the virtual-kubelet node to the instance metadata of Kip Cells:

- cluster-location
- cluster-name
- cluster-uid

After these were added, DaemonSet Pods now start up and run but with errors about service accounts in the logs.

I also cleaned up initialization of our gceClient and did a minor commit to change the order layers are created in our Dockerfile.
