### PR TITLE
Fix StartTime in pod and container stats

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -365,7 +365,7 @@ resource "aws_instance" "k8s-node" {
       private_key = local.create_ssh_key ? tls_private_key.ssh-key.0.private_key_pem : null
     }
     inline = [
-      "timeout 300 bash -c 'echo Waiting for cluster to come up; while true; do kubectl get svc kubernetes 2>/dev/null && exit 0; sleep 1; done'",
+      "timeout 600 bash -x -c 'echo Waiting for cluster to come up; while true; do kubectl cluster-info && kubectl get svc kubernetes && exit 0; sleep 5; done'",
     ]
   }
 

--- a/pkg/server/getstatssummary.go
+++ b/pkg/server/getstatssummary.go
@@ -94,9 +94,11 @@ func (p *InstanceProvider) GetStatsSummary(ctx context.Context) (*stats.Summary,
 			klog.V(2).Infof("not enough metrics yet for pod %s", pod.Name)
 			continue
 		}
-		// First metrics sample from the pod.
-		firstSample := podMetricsItems[0]
-		startTime := metav1.NewTime(firstSample.Timestamp.Time)
+		// The docs say PodStats.StartTime is:
+		//	 The time at which data collection for the pod-scoped (e.g.
+		//	 network) stats was (re)started.
+		// That is, when the pod or container was started.
+		startTime := metav1.NewTime(pod.CreationTimestamp.Time)
 		// Last two samples from the pod, with the latest metrics.
 		currentSample := podMetricsItems[len(podMetricsItems)-1]
 		previousSample := podMetricsItems[len(podMetricsItems)-2]


### PR DESCRIPTION
This is the time when the pod or container was started, not the timestamp of the first sample we have in memory (which is a moving window of samples).