### PR TITLE
Auto-allocate CIDRs on GCP

### DIFF
--- a/deploy/manifests/virtual-kubelet/base/deployment.yaml
+++ b/deploy/manifests/virtual-kubelet/base/deployment.yaml
@@ -90,7 +90,7 @@ spec:
             cpu: "2"
             memory: "1Gi"
           requests:
-            cpu: "100m"
+            cpu: "10m"
             memory: "100Mi"
         volumeMounts:
         - name: data

--- a/deploy/terraform-gcp/env.tfvars.example
+++ b/deploy/terraform-gcp/env.tfvars.example
@@ -1,15 +1,13 @@
+#
+# See variables.tf for all possible configuration variables.
+#
+
 # Cluster name.
 #cluster-name = ""
 
 # Region and zone to create resources in.
 #region = ""
 #zone = ""
-
-# Kubernetes pod CIDR.
-#pod-cidr = ""
-
-# Kubernetes service CIDR. Cluster IPs will be allocated from this CIDR.
-#service-cidr = ""
 
 # The path for a virtual-kubelet kustomize directory.
 #kustomize-dir = ""

--- a/deploy/terraform-gcp/variables.tf
+++ b/deploy/terraform-gcp/variables.tf
@@ -18,13 +18,13 @@ variable "zone" {
 }
 
 variable "pod-cidr" {
-  default     = "10.20.0.0/16"
-  description = "The CIDR in the cluster used for pod IP addresses."
+  default     = ""
+  description = "The CIDR in the cluster used for pod IP addresses. By default, a CIDR will be allocated automatically."
 }
 
 variable "service-cidr" {
-  default     = "10.96.0.0/16"
-  description = "The CIDR in the cluster used for service IP addresses."
+  default     = ""
+  description = "The CIDR in the cluster used for service IP addresses. By default, a CIDR will be allocated automatically."
 }
 
 variable "kustomize-dir" {

--- a/pkg/server/cloud/gce/network.go
+++ b/pkg/server/cloud/gce/network.go
@@ -66,9 +66,14 @@ func (c *gceClient) getVPCRegionCIDRs(vpcName string) ([]string, error) {
 	if err != nil {
 		return nil, util.WrapError(err, "Error listing network subnets in region")
 	}
-	vpcCIDRs := make([]string, len(subnets))
-	for i := range subnets {
-		vpcCIDRs[i] = subnets[i].IpCidrRange
+	vpcCIDRs := make([]string, 0, len(subnets))
+	for _, subnet := range subnets {
+		vpcCIDRs = append(vpcCIDRs, subnet.IpCidrRange)
+		for _, secondary := range subnet.SecondaryIpRanges {
+			if secondary != nil {
+				vpcCIDRs = append(vpcCIDRs, secondary.IpCidrRange)
+			}
+		}
 	}
 	if len(vpcCIDRs) == 0 {
 		return nil, fmt.Errorf("Could not list any subnets in %s - %s", vpcName, c.region)


### PR DESCRIPTION
This will have the GCP Terraform config auto-allocate the service and pod CIDRs by default, so there will be no range collision when multiple users provision clusters in the same project/network.

I also reduced the default CPU request for the VK deployment to make sure it fits into an n1-standard-1 instance. With the default system pods, it's close to being full on GKE.