### PR TITLE
Add logging.write and monitoring.write scopes to GCE instances

### DIFF
--- a/pkg/server/cloud/gce/gce.go
+++ b/pkg/server/cloud/gce/gce.go
@@ -47,6 +47,7 @@ const (
 
 type gceClient struct {
 	service              *compute.Service
+	clientEmail          string
 	controllerID         string
 	nametag              string
 	projectID            string

--- a/pkg/server/cloud/gce/instances.go
+++ b/pkg/server/cloud/gce/instances.go
@@ -161,6 +161,15 @@ func (c *gceClient) createInstanceSpec(node *api.Node, image cloud.Image, metada
 		Metadata: &compute.Metadata{
 			Items: c.createInstanceMetadata(string(decodedUserData)),
 		},
+		ServiceAccounts: []*compute.ServiceAccount{
+			{
+				Email: c.clientEmail,
+				Scopes: []string{
+					"https://www.googleapis.com/auth/logging.write",
+					"https://www.googleapis.com/auth/monitoring.write",
+				},
+			},
+		},
 	}
 	if node.Spec.Spot {
 		ar := false

--- a/pkg/server/cloud/gce/option.go
+++ b/pkg/server/cloud/gce/option.go
@@ -113,6 +113,8 @@ func (w withCredentials) Apply(c *gceClient) error {
 		return err
 	}
 
+	c.clientEmail = w.clientEmail
+
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 	c.service, err = compute.NewService(ctx, option.WithCredentialsJSON(b))


### PR DESCRIPTION
We plan to run a monitoring and a logging agent on GCE instances to
better integrate with stackdriver. This adds the necessary scopes so
that those agents can send data to SD.