### PR TITLE
Build multiple init-cert images

### DIFF
--- a/scripts/init-cert/Dockerfile
+++ b/scripts/init-cert/Dockerfile
@@ -1,5 +1,10 @@
 FROM debian:stable-slim
 
+ARG K8S_VERSION_MAJOR
+RUN test -n "$K8S_VERSION_MAJOR"
+ARG K8S_VERSION_MINOR
+RUN test -n "$K8S_VERSION_MINOR"
+
 ENV DEBIAN_FRONTEND "noninteractive"
 
 RUN apt-get update -y && \
@@ -8,8 +13,13 @@ RUN apt-get update -y && \
 
 RUN mkdir -p /usr/local/bin
 
-RUN curl -fL https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl > /usr/local/bin/kubectl
-RUN chmod +x /usr/local/bin/kubectl
+RUN set -e; \
+    echo "installing kubectl for kubernetes ${K8S_VERSION_MAJOR}.${K8S_VERSION_MINOR}"; \
+    vsn=$(curl -fL https://storage.googleapis.com/kubernetes-release/release/stable-${K8S_VERSION_MAJOR}.${K8S_VERSION_MINOR}.txt); \
+    curl -fL https://storage.googleapis.com/kubernetes-release/release/${vsn}/bin/linux/amd64/kubectl > /usr/local/bin/kubectl-${vsn}; \
+    chmod 755 /usr/local/bin/kubectl-${vsn}; \
+    ln -snf /usr/local/bin/kubectl-${vsn} /usr/local/bin/kubectl; \
+    echo "installed kubectl ${vsn}"
 
 RUN curl -fL https://github.com/ldx/token2kubeconfig/releases/download/v0.0.2/token2kubeconfig-amd64 > /usr/local/bin/token2kubeconfig
 RUN chmod +x /usr/local/bin/token2kubeconfig

--- a/scripts/init-cert/build.sh
+++ b/scripts/init-cert/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+DKR=${DKR:-docker}
+PUSH_IMAGES=${PUSH_IMAGES:-false}
+
+major=1
+for minor in $(seq 12 18); do
+    tag="k8s-${major}.${minor}"
+    docker build -t elotl/init-cert:${tag} --build-arg K8S_VERSION_MAJOR=${major} --build-arg K8S_VERSION_MINOR=${minor} .
+    $PUSH_IMAGES && docker push elotl/init-cert:${tag} || true
+done
+docker tag elotl/init-cert:k8s-1.18 elotl/init-cert:latest
+$PUSH_IMAGES && docker push elotl/init-cert:latest || true


### PR DESCRIPTION
Since init-cert uses kubectl, we need to ensure the right version is
used (kubectl guarantees one minor version skew compatibility).

I added a script to build multiple images for each Kubernetes version
between 1.12 and 1.18. Depending on the cluster, the use can simply
change the image to e.g. elotl/init-cert:k8s-1.14 in a 1.14.x cluster.