### PR TITLE
GCE Marketplace: env var to run kip using the mock cloud provider

### DIFF
--- a/pkg/server/cloud/mock.go
+++ b/pkg/server/cloud/mock.go
@@ -18,6 +18,7 @@ package cloud
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/elotl/kip/pkg/api"
 	"github.com/elotl/kip/pkg/util"
@@ -175,6 +176,9 @@ func (m *MockCloudClient) GetAttributes() CloudAttributes {
 	return CloudAttributes{
 		DiskProductName: api.StorageGP2,
 		FixedSizeVolume: false,
+		Provider:        ProviderAWS,
+		Region:          "us-east-1",
+		Zone:            m.Subnets[0].AZ,
 	}
 }
 
@@ -309,6 +313,25 @@ func NewMockClient() *MockCloudClient {
 
 	net.RouteAdder = func(destinationCIDR, nextHop string) error {
 		return nil
+	}
+
+	net.AvailabilityChecker = func() (bool, error) {
+		return true, nil
+	}
+
+	net.ImageGetter = func(BootImageSpec) (Image, error) {
+		t := time.Now()
+		img := Image{
+			ID:           "1234",
+			Name:         "MockImage",
+			RootDevice:   "/dev/xvda",
+			CreationTime: &t,
+		}
+		return img, nil
+	}
+
+	net.DNSInfoGetter = func() ([]string, []string, error) {
+		return []string{"cloud.internal"}, []string{"1.1.1.1"}, nil
 	}
 
 	net.SubnetGetter = func() ([]SubnetAttributes, error) {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"strconv"
 
 	"github.com/elotl/kip/pkg/api"
 	"github.com/elotl/kip/pkg/api/validation"
@@ -267,6 +268,11 @@ func setupAzureEnvVars(c *AzureConfig) error {
 
 func configureCloudProvider(cf *ServerConfigFile, controllerID, nametag string) (cloud.CloudClient, error) {
 	// see which cloud is non-null, take first
+	mockCloudAPI := os.Getenv("MOCK_CLOUD_API")
+	if val, err := strconv.ParseBool(mockCloudAPI); err == nil && val {
+		klog.Warningf("Running with a mocked cloud API client. This kip installation can not be changed to run a real k8s cluster")
+		return cloud.NewMockClient(), nil
+	}
 	cc := cf.Cloud
 	numClouds := 0
 	if cc.AWS != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -164,7 +164,7 @@ func ensureRegionUnchanged(etcdClient *etcd.SimpleEtcd, region string) error {
 		return fmt.Errorf(
 			"error: region has changed from %s to %s. "+
 				"This is unsupported. "+
-				"Please delete all cluster resources and rename your cluster",
+				"To change regions, delete all existing kip resources and instances and delete the kip persistent volume",
 			savedRegion, region)
 	}
 	return nil
@@ -222,12 +222,14 @@ func NewInstanceProvider(configFilePath, nodeName, internalIP, serverURL, networ
 	if err != nil {
 		return nil, fmt.Errorf("error configuring cloud client: %v", err)
 	}
+
 	klog.V(5).Infof("ensuring cloud region is unchanged")
 	cloudRegion := cloudClient.GetAttributes().Region
 	err = ensureRegionUnchanged(etcdClient, cloudRegion)
 	if err != nil {
 		return nil, fmt.Errorf("error ensuring Kip region is unchanged: %v", err)
 	}
+
 	klog.V(5).Infof("creating internal client certificate")
 	clientCert, err := certFactory.CreateClientCert()
 	if err != nil {


### PR DESCRIPTION
If MOCK_CLOUD_API=true (or some variation of true) then run kip with a mocked out cloud provider.  To do this, I've added a couple more fake methods in the cloud mock.

One caveat of this change is that the user cannot run with the mock cloud provider and then, using the same persistent volume, change to running with a regular cloud provider.  That will cause issues with the code that detects a region change.  While it's unlikely a user would change regions in kip (it was an easy change to make in milpa's configuration), I still think we should catch that.  There are ways around this issue but I think we don't need to implement them at this time.