### PR TITLE
Refactor templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - AWS_DEFAULT_REGION=us-east-1
   - TERRAFORM_VERSION=0.12.21
   - KUBECTL_VERSION=1.18.0
+  - KUSTOMIZE_VERSION=3.6.1
   - GOOGLE_APPLICATION_CREDENTIALS=.account.json
   - secure: eQV5LiSp5XP7pL4gFYR98uL8aMdmeI5J5h3oOsRZ8fEBVFB0XBX0QDmK6zpaxAx2GoHfFC6ioUdNQjiVmnatwRHnnmxlplD8w99LXcvYkdfS6mtbyhdd2gZNv3gypIFqzyG73zqqhosNSUou1H8GSMWaQSk+P1Y6W7jHKsPEtrV5fepwu6tSpIK+DZbN2mrbyKdKMgWkdAPd/ni++bLDrvwlsoC8MOyWLerDnjRdC/Enzp4OgP9XR/JcqaNyXGLhMRLrN/PwWUk6mayjiVdGk9MLM+YuzCaVaqmtlHZMQHQQzP8r8KO4wZt+ApfNkVlwj44+ya7YoMkSguS5U4AmC0I3NntwhA4L8tpezk/FhSF0FwmP2MDKbWajYWtptThoXRQ5yU/UTJD/hWPofZPm9halZs7yqtoYNLXQWGfS06zROMyLoDOI7uw8b3VSSxQwVjcy8zjmJ/X5I/Dpl/QXsFGaU3u3u/Q0gE4V7ve/9fhbcittq1pRamcVvvZE/jUiXxWEiVEQ39W2dF/Fsp71nvm9Q7vTkgFKPtZV+lwFykTf9gg8vdbRTJ2qlYz668mQ0B+XUhueR+gxaDV+pIFKHRM+/B32fakTwBkXFHGtonodSL8TCeOydpmWLzJ4KexHAjL9AaUoqj4XKfQtAmtNppPmHpScONfhEZ65V+EnXiE=
   - secure: rwyN3nyJ0+ghzNDC5TmpTZNHFvxdapiyFGTSNgpgsdzBXrBVYtPAc1ygAMYYauS8GyrTTg55wbrZUTrSspWirecwVprtLg3Lby/VacXz/qCtZ5wBsYhWJTkbgX0q/H9j3JqGTPUjJORRe5krRHmCrW2nhy+FrE731IcKgItspCGyXoGbh/O3z5yIZIU9NWKX/BqgzjUf7cYdkm25dphQOUkNJOBzeG7Nv7DumzC0V524F4s2GK4Eqp4P/SAENDjdmnwMw+SC1peikAo1XHmWgz72EvVKncF7b6PVs80rnAOEwNg1Hs8B90VWiZpW+qPWBhJuNjoXOTdNxjaAs0y5S/9BLBNcqvIp6Kj1/QtMuCbk63pVYa9OiUv+2XLlJJ4om0BcqE/CghQvhKtOuNN9gxSHjXP7RP1yqyBMVY3jsXQHU9IZcpbaF2ZmRB587gHCUcDXZbz+wLvBLnw0UjKxCdcJrop9zg7ylwo4r5h2ojfhfXt1lYqH2Lvpz8n98uHYVOvgdShxQsDmw1W37ggNB4jMVxcv7atUBI8jzYMNOg80Qjp2ghuGjYon9KQTMis8ykBg6qOFLwS62cWe6GbZ6LQmjhLg/ZOOieD512p/Re/s47e5cakuHqC//VY8rqDPiEsXCHc0lhZ1HWy5akqes/gYkvoGsNWGUcT5sKdIedg=
@@ -30,6 +31,7 @@ before_script:
 - sudo apt-get update -y && sudo apt-get install -y google-cloud-sdk awscli jq
 - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
   && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+- curl -fsL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz | sudo tar -C /usr/local/bin/ -xvzf - && sudo chmod +x /usr/local/bin/kustomize
 - curl -Os https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
   && sudo unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin/
 - GO111MODULE=on go get -u k8s.io/gengo/examples/deepcopy-gen

--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ There are two ways to get Kip up and running.
 
 Prequisites:
 - An AWS or Google Cloud account
-- [Terraform](https://www.terraform.io/downloads.html) (tested with terraform 0.12)
+- [Terraform](https://www.terraform.io/downloads.html) >= 0.12
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) >= 1.14
-- jq and [aws-cli](https://aws.amazon.com/cli/) if using AWS
+- [kustomize](https://github.com/kubernetes-sigs/kustomize) >= 3.0.0
+- [jq](https://github.com/stedolan/jq) and [aws-cli](https://aws.amazon.com/cli/) if using AWS
 
 In [deploy/terraform-aws](deploy/terraform-aws), you will find a terraform config that creates a simple one master, one worker cluster and starts Kip on AWS.
 
@@ -80,7 +81,7 @@ The resources in [deploy/manifests/kip](deploy/manifests/kip) create ServiceAcco
 
 Once credentials are set up, apply [deploy/manifests/kip/base](deploy/manifests/kip/base) to create the necessary kubernetes resources to support and run the provider:
 
-    $ kubectl apply -k deploy/manifests/kip/base
+    $ kustomize build deploy/manifests/kip/base | kubectl apply -f -
 
 For rendering the manifests, [kustomize](https://kustomize.io/) is used. You can create your own overlays on top of the base template. For example, to override provider.yaml, Kip's configuration file:
 
@@ -97,10 +98,9 @@ For rendering the manifests, [kustomize](https://kustomize.io/) is used. You can
     > - behavior: merge
     >   files:
     >   - provider.yaml
-    >   name: kip-config
-    >   namespace: kube-system
+    >   name: config
     EOF
-    $ kubectl apply -k deploy/manifests/kip/overlays/local-config
+    $ kustomize build deploy/manifests/kip/overlays/local-config | kubectl apply -f -
 
 After applying, you should see a new kip pod in the kube-system namespace and a new node named "kip-0" in the cluster.
 

--- a/deploy/manifests/kip/README.md
+++ b/deploy/manifests/kip/README.md
@@ -4,9 +4,9 @@ Here you can find kustomize templates for deploying Kip.
 
 ## Deploy
 
-Use the base directory for a basic setup:
+You need [kustomize](https://github.com/kubernetes-sigs/kustomize) and [kubectl](https://github.com/kubernetes/kubectl). Use the base directory for a basic setup:
 
-    $ kubectl apply -k base/
+    $ kustomize build base/ | kubectl apply -f -
 
 ## Override Settings or Configuration
 
@@ -19,10 +19,9 @@ Templating makes it really easy to override certain parameters or configuration 
     bases:
     - ../../base
     configMapGenerator:
-    - name: kip-config
-      namespace: kube-system
+    - name: config
       behavior: merge
       files:
       - provider.yaml
     EOF
-    $ kubectl apply -k overlays/local-dev/
+    $ kustomize build overlays/local-dev/ | kubectl apply -f -

--- a/deploy/manifests/kip/base/kustomization.yaml
+++ b/deploy/manifests/kip/base/kustomization.yaml
@@ -1,10 +1,24 @@
+namespace: kube-system
+namePrefix: kip-
 resources:
 - pvc.yaml
 - statefulset.yaml
 - sa.yaml
-- network-agent-sa.yaml
+- network-agent.yaml
 configMapGenerator:
-- name: kip-config
-  namespace: kube-system
+- name: config
   files:
   - provider.yaml
+vars:
+- name: NETWORK_AGENT_SERVICE_ACCOUNT
+  objref:
+    kind: ServiceAccount
+    name: network-agent
+    apiVersion: v1
+- name: KIP_NAMESPACE
+  objref:
+    kind: StatefulSet
+    name: provider
+    apiVersion: apps/v1
+  fieldRef:
+    fieldpath: metadata.namespace

--- a/deploy/manifests/kip/base/network-agent.yaml
+++ b/deploy/manifests/kip/base/network-agent.yaml
@@ -1,14 +1,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: vk-network-agent
-  namespace: kube-system
+  name: network-agent
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: vk-network-agent
-  namespace: kube-system
+  name: network-agent
 rules:
   - apiGroups:
     - ""
@@ -42,21 +40,19 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: vk-network-agent
+  name: network-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: vk-network-agent
+  name: network-agent
 subjects:
 - kind: ServiceAccount
-  name: vk-network-agent
-  namespace: kube-system
+  name: network-agent
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vk-network-agent
-  namespace: kube-system
+  name: network-agent
   annotations:
-    kubernetes.io/service-account.name: vk-network-agent
+    kubernetes.io/service-account.name: $(NETWORK_AGENT_SERVICE_ACCOUNT)
 type: kubernetes.io/service-account-token

--- a/deploy/manifests/kip/base/pvc.yaml
+++ b/deploy/manifests/kip/base/pvc.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: provider-data
-  namespace: kube-system
 spec:
   accessModes:
     - ReadWriteOnce

--- a/deploy/manifests/kip/base/sa.yaml
+++ b/deploy/manifests/kip/base/sa.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kip
+  name: provider
 rules:
   - apiGroups:
     - authentication.k8s.io
@@ -216,18 +216,16 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kip
-  namespace: kube-system
+  name: provider
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kip
+  name: provider
 roleRef:
   kind: ClusterRole
-  name: kip
+  name: provider
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: kip
-  namespace: kube-system
+  name: provider

--- a/deploy/manifests/kip/base/statefulset.yaml
+++ b/deploy/manifests/kip/base/statefulset.yaml
@@ -1,34 +1,34 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kip
+  name: provider
   labels:
-    app: kip
+    app: kip-provider
 spec:
   ports:
   - port: 10250
-    name: kip
-  clusterIP: None
+    name: kubelet
+  - port: 10255
+    name: kubelet-readonly
   selector:
-    app: kip
+    app: kip-provider
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: kip
-  namespace: kube-system
+  name: provider
   labels:
-    app: kip
+    app: kip-provider
 spec:
-  serviceName: kip
+  serviceName: provider
   replicas: 1
   selector:
     matchLabels:
-      app: kip
+      app: kip-provider
   template:
     metadata:
       labels:
-        app: kip
+        app: kip-provider
     spec:
       affinity:
         nodeAffinity:
@@ -46,7 +46,7 @@ spec:
               - key: app
                 operator: In
                 values:
-                - kip
+                - kip-provider
             topologyKey: failure-domain.beta.kubernetes.io/zone
       initContainers:
       - command:
@@ -77,7 +77,7 @@ spec:
         - --provider-config
         - /etc/kip/provider.yaml
         - --network-agent-secret
-        - kube-system/vk-network-agent
+        - $(KIP_NAMESPACE)/$(NETWORK_AGENT_SERVICE_ACCOUNT)
         - --disable-taint
         - --klog.logtostderr
         - --klog.v=2
@@ -141,7 +141,7 @@ spec:
           readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
-      serviceAccountName: kip
+      serviceAccountName: provider
       tolerations:
       - key: "node-role.kubernetes.io/master"
         effect: "NoSchedule"
@@ -151,7 +151,7 @@ spec:
           claimName: provider-data
       - name: provider-yaml
         configMap:
-          name: kip-config
+          name: config
           items:
           - key: provider.yaml
             path: provider.yaml

--- a/deploy/manifests/kip/overlays/cloudinit/kustomization.yaml
+++ b/deploy/manifests/kip/overlays/cloudinit/kustomization.yaml
@@ -3,8 +3,7 @@ bases:
 patchesStrategicMerge:
 - statefulset.yaml
 configMapGenerator:
-- name: kip-config
-  namespace: kube-system
+- name: config
   behavior: merge
   files:
   - cloudinit.yaml

--- a/deploy/manifests/kip/overlays/cloudinit/statefulset.yaml
+++ b/deploy/manifests/kip/overlays/cloudinit/statefulset.yaml
@@ -1,15 +1,14 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: kip
-  namespace: kube-system
+  name: provider
 spec:
   template:
     spec:
       volumes:
       - name: provider-yaml
         configMap:
-          name: kip-config
+          name: config
           items:
           - key: cloudinit.yaml
             path: cloudinit.yaml

--- a/deploy/manifests/kip/overlays/conformance-tests/kustomization.yaml
+++ b/deploy/manifests/kip/overlays/conformance-tests/kustomization.yaml
@@ -1,8 +1,7 @@
 bases:
 - ../../base
 configMapGenerator:
-- name: kip-config
-  namespace: kube-system
+- name: config
   behavior: merge
   files:
   - provider.yaml

--- a/deploy/manifests/kip/overlays/gcp/kustomization.yaml
+++ b/deploy/manifests/kip/overlays/gcp/kustomization.yaml
@@ -1,8 +1,7 @@
 bases:
 - ../../base
 configMapGenerator:
-- name: kip-config
-  namespace: kube-system
+- name: config
   behavior: merge
   files:
   - provider.yaml

--- a/deploy/manifests/kip/overlays/minikube/kustomization.yaml
+++ b/deploy/manifests/kip/overlays/minikube/kustomization.yaml
@@ -4,15 +4,14 @@
 #     $ cat <<EOF > overlays/local-minikube/kustomization.yaml
 #     bases:
 #     - ../minikube
+#     namespace: kube-system
 #     configMapGenerator:
 #     - name: kip-config
-#       namespace: kube-system
 #       behavior: merge
 #       files:
 #       - provider.yaml
 #     secretGenerator:
 #     - name: kip-secrets
-#       namespace: kube-system
 #       literals:
 #       - AWS_ACCESS_KEY_ID=...
 #       - AWS_SECRET_ACCESS_KEY=...
@@ -23,16 +22,13 @@
 # 3. Set your AWS access keys:
 #     $ vi overlays/local-minikube/kustomization.yaml
 # 4. Apply via:
-#     $ kubectl apply -k overlays/local-minikube
-#    or, if you have kustomize installed:
 #     $ kustomize build overlays/local-minikube | kubectl apply -f -
 bases:
 - ../../base
 patchesStrategicMerge:
 - statefulset.yaml
 configMapGenerator:
-- name: kip-config
-  namespace: kube-system
+- name: config
   behavior: merge
   files:
   - provider.yaml

--- a/deploy/manifests/kip/overlays/minikube/statefulset.yaml
+++ b/deploy/manifests/kip/overlays/minikube/statefulset.yaml
@@ -1,8 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: kip
-  namespace: kube-system
+  name: provider
 spec:
   template:
     spec:
@@ -10,4 +9,4 @@ spec:
       - name: kip
         envFrom:
         - secretRef:
-            name: kip-secrets
+            name: provider-secret

--- a/deploy/terraform-aws/README.md
+++ b/deploy/terraform-aws/README.md
@@ -33,7 +33,7 @@ You can now ssh into the instance using the username "ubuntu", and the ssh key y
     $ kubectl get nodes
     NAME                          STATUS   ROLES    AGE   VERSION
     ip-10-0-26-113.ec2.internal   Ready    master   67s   v1.17.3
-    kip               Ready    agent    13s   v1.14.0-vk-v0.0.1-125-g3b2cc98
+    kip-provider-0                Ready    agent    13s   v1.14.0-vk-v0.0.1-125-g3b2cc98
 
 If you haven't set an existing ssh key in your configuration, a new ssh key has been created. You can extract and use it via:
 

--- a/deploy/terraform-aws/main.tf
+++ b/deploy/terraform-aws/main.tf
@@ -292,7 +292,7 @@ locals {
 }
 
 data "external" "manifest" {
-  program = ["bash", "-c", "set -e; set -o pipefail; kubectl kustomize ${var.kustomize-dir} | jq -s -R '{\"output\": .}'"]
+  program = ["bash", "-c", "set -e; set -o pipefail; kustomize build ${var.kustomize-dir} | jq -s -R '{\"output\": .}'"]
 }
 
 data "template_file" "node-userdata" {

--- a/deploy/terraform-aws/node.sh
+++ b/deploy/terraform-aws/node.sh
@@ -87,6 +87,6 @@ curl -fL https://raw.githubusercontent.com/elotl/milpa-deploy/master/deploy/cni/
 # Don't run kube-proxy on kip.
 kubectl patch -p '{"spec":{"template":{"spec":{"affinity":{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"type","operator":"NotIn","values":["virtual-kubelet"]}]}]}}}}}}}' -n kube-system ds kube-proxy
 
-# Deploy VK.
+# Deploy main manifest.
 echo "${kip_manifest}" | base64 --decode > /tmp/kip.yaml
 kubectl apply -f /tmp/kip.yaml

--- a/deploy/terraform-gcp/README.md
+++ b/deploy/terraform-gcp/README.md
@@ -6,6 +6,7 @@ The Terraform config here can be used to provision a simple test cluster with Ki
 
 You need:
 * a GCP account configured and the necessary services enabled
+* kustomize >= 3.0.0
 * kubectl >= 1.14
 * Terraform >= 0.12
 
@@ -27,7 +28,7 @@ This will create a new GKE cluster and deploy Kip:
     $ kubectl get nodes
     NAME                                        STATUS   ROLES    AGE    VERSION
     gke-vk-node-pool-vk-9e5f3d39-44rg           Ready    <none>   171m   v1.14.10-gke.36
-    kip                             Ready    agent    108s
+    kip-provider-0                              Ready    agent    108s
 
 ## Run a Pod via Virtual Kubelet
 

--- a/deploy/terraform-gcp/main.tf
+++ b/deploy/terraform-gcp/main.tf
@@ -165,8 +165,8 @@ resource "null_resource" "deploy" {
       "-x",
       "-c",
     ]
-    # This needs kubectl >= 1.14.
-    command = "kubectl apply -k ${var.kustomize-dir}"
+    # This needs kubectl and kustomize.
+    command = "kustomize build ${var.kustomize-dir} | kubectl apply -f -"
   }
 
   triggers = {

--- a/deploy/terraform-vpn/README.md
+++ b/deploy/terraform-vpn/README.md
@@ -8,6 +8,7 @@ For more information on Site-to-Site VPN, see [documentation from AWS](https://d
 
 For provisioning, you need:
 * terraform >= 0.12
+* kustomize >= 3.0.0
 * kubectl >= 1.14
 
 The VPN client uses IPsec, and needs a few kernel modules available on the worker node:

--- a/deploy/terraform-vpn/kustomization/kustomization.yaml.tmpl
+++ b/deploy/terraform-vpn/kustomization/kustomization.yaml.tmpl
@@ -1,5 +1,6 @@
 bases:
 - ../../manifests/kip/overlays/minikube/
+namespace: kube-system
 resources:
 - vpn-deployment.yaml
 - node-local-dns.yaml
@@ -8,20 +9,18 @@ patchesJson6902:
     group: apps
     version: v1
     kind: StatefulSet
-    name: kip
+    name: provider
   path: command-extra-args.yaml
 configMapGenerator:
-- name: kip-config
-  namespace: kube-system
+- name: config
   behavior: merge
   files:
   - provider.yaml
 - name: aws-vpn-client-config
-  namespace: kube-system
-  env: aws-vpn-client.env
+  envs:
+  -  aws-vpn-client.env
 secretGenerator:
-- name: kip-secrets
-  namespace: kube-system
+- name: provider-secret
   literals:
   - AWS_ACCESS_KEY_ID=${aws_access_key_id}
   - AWS_SECRET_ACCESS_KEY=${aws_secret_access_key}

--- a/deploy/terraform-vpn/kustomization/node-local-dns.yaml.tmpl
+++ b/deploy/terraform-vpn/kustomization/node-local-dns.yaml.tmpl
@@ -17,7 +17,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: node-local-dns
-  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -26,7 +25,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kube-dns-upstream
-  namespace: kube-system
   labels:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
@@ -49,7 +47,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: node-local-dns
-  namespace: kube-system
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 data:
@@ -105,7 +102,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: node-local-dns
-  namespace: kube-system
   labels:
     k8s-app: node-local-dns
     kubernetes.io/cluster-service: "true"

--- a/deploy/terraform-vpn/kustomization/vpn-deployment.yaml.tmpl
+++ b/deploy/terraform-vpn/kustomization/vpn-deployment.yaml.tmpl
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: aws-vpn-client
   name: aws-vpn-client
-  namespace: kube-system
 spec:
   replicas: 1
   selector:

--- a/deploy/terraform-vpn/main.tf
+++ b/deploy/terraform-vpn/main.tf
@@ -135,8 +135,8 @@ resource "null_resource" "deploy" {
   count = var.deploy_to_kubernetes ? 1 : 0
 
   provisioner "local-exec" {
-    # This needs kubectl >= 1.14.
-    command = "kubectl apply -k ${path.module}/kustomization/"
+    # This needs kustomize and kubectl.
+    command = "kustomize build ${path.module}/kustomization/ | kubectl apply -f -"
     interpreter = [
       "bash",
       "-x",

--- a/deploy/terraform-vpn/variables.tf
+++ b/deploy/terraform-vpn/variables.tf
@@ -69,7 +69,7 @@ variable "tunnel2_psk" {
 variable "deploy_to_kubernetes" {
   type        = bool
   default     = true
-  description = "Whether the generated Kubernetes resources will be applied via kubectl. Disable if you only need the kustomization/ directory generated, and you plan to apply it separately. If enabled, it needs kubectl >= 1.14."
+  description = "Whether the generated Kubernetes resources will be applied via kustomize and kubectl. Disable if you only need the kustomization/ directory generated, and you plan to apply it separately. If enabled, it needs kustomize and kubectl to be installed."
 }
 
 variable "static_routes_only" {

--- a/scripts/run_smoke_test.sh
+++ b/scripts/run_smoke_test.sh
@@ -19,9 +19,9 @@ export KUBECONFIG=$(mktemp)
 cleanup() {
     kubectl get pods -A || true
     kubectl get nodes || true
-    kubectl -n kube-system describe pod -l app=kip || true
-    kubectl logs -n kube-system -l app=kip -c init-cert --tail=-1 || true
-    kubectl logs -n kube-system -l app=kip -c kip --tail=-1 || true
+    kubectl -n kube-system describe pod -l app=kip-provider || true
+    kubectl logs -n kube-system -l app=kip-provider -c init-cert --tail=-1 || true
+    kubectl logs -n kube-system -l app=kip-provider -c kip --tail=-1 || true
     kubectl delete pod nginx > /dev/null 2>&1 || true
     kubectl delete svc nginx > /dev/null 2>&1 || true
     kubectl delete pod test > /dev/null 2>&1 || true
@@ -37,7 +37,7 @@ cleanup() {
 update_vk() {
     local version="$(git describe)"
     local patch="{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"image\":\"elotl/kip:$version\",\"name\":\"kip\"}]}}}}"
-    kubectl patch -n kube-system statefulset kip -p "$patch"
+    kubectl patch -n kube-system statefulset kip-provider -p "$patch"
 }
 
 run_smoke_test() {


### PR DESCRIPTION
The goal is to make it easier to override parameters that apply to every resource we deploy, such as the namespace, name prefixes and suffixes.

Note: unfortunately, we can't use `kubectl kustomize` or `kubectl apply -k` anymore, since it comes with an old version of kustomize built in. I added kustomize to our build, and also updated our docs.