### PR TITLE
Add compute scope to GKE node pool in TF

### DIFF
--- a/deploy/terraform-gcp/main.tf
+++ b/deploy/terraform-gcp/main.tf
@@ -64,6 +64,7 @@ resource "google_container_node_pool" "node-pool" {
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/compute",
     ]
   }
 }


### PR DESCRIPTION
This way the user does not need to configure their GCE service account
credentials via provider.yaml. In fact, the whole GCE section can be
left empty:

    cloud:
      gce: {}

and Kip will auto-detect everything.