### PR TITLE
Create init-cert image in build, and update latest tags after tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ script:
 - make
 - "./scripts/run_tests.sh"
 - make img login-img push-img DKR=docker
+- "./scripts/init-cert/build.sh"
 - "./scripts/run_smoke_test.sh"
 - "./scripts/push_to_gcr_ecr.sh"
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ script:
 - "./scripts/init-cert/build.sh"
 - "./scripts/run_smoke_test.sh"
 - "./scripts/push_to_gcr_ecr.sh"
+- "./scripts/update_latest_tags.sh"
 notifications:
   slack:
     secure: d4Y/cOEzbFc7RHwizwVsdaTCURsQ/Rmm2kyGgw3WboO7ijU0PRNTioktRxB5byJAhCI79bDJbLxwNRempIdSlzG4sL7UHK4Nyxb0t5XxBLDzqD1nJPL652r5oQ8W+ru9tMKtO4xWc2ELl3spe4Lb1pyXHCSpvkd++IgZBKbpOdaCs4XNWm94sVXVRPiJOs+0tlX+gYjnGkje91MaVYJM/XMWNxOut2t6BZ1raYm+mYJUSfC7CFJPAha8+1x8S7CEbJE8Xa63gV37HUDsZbZfYdpljm3/nd6cdJzDYf51Cvdwh/DUqcBvw2AUm8AMlMUF7hGkSTS0gTRkO7nkURkm6eGJesHp0aEGg24TFIFaCtcI4rPq49GDPKOmAJUHtWev1oPw2SCIXw4cDkulKoYzqj+amXSfXDVN3Uza3zVGY445Wd5VLkiEoCvvE06Hp4gjnDfvszTh9Kj/CK7x8e4BtPyuq0oxn64/SyoSb9CfZL0VqNar4hlms44CYMdnLGzf6Sicc7+Og1aC3cd5/GlVRTtNsaf6qHVtQbhW9lar2fjpO2B2KxiOLmAvwp6aSN+Zmwif/xGfwqAJnQllB3d/ewiTjK34RJiKDg6BSUecC2Dp8jSzv9qpXYWvjSHM2kgltXgs21q7Pm7L6ISdhn6ek23ASe0N85qyyrNglF79mWA=

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,6 @@ DKR=docker
 GIT_VERSION=$(shell git describe --dirty)
 CURRENT_TIME=$(shell date +%Y%m%d%H%M%S)
 IMAGE_TAG=$(GIT_VERSION)
-ifneq ($(findstring -,$(GIT_VERSION)),)
-IMAGE_DEV_OR_LATEST=dev
-else
-IMAGE_DEV_OR_LATEST=latest
-endif
 
 LD_VERSION_FLAGS=-X main.buildVersion=$(GIT_VERSION) -X main.buildTime=$(CURRENT_TIME) -X github.com/elotl/kip/pkg/util.VERSION=$(GIT_VERSION)
 LDFLAGS=-ldflags "$(LD_VERSION_FLAGS)"
@@ -43,8 +38,7 @@ kipctl: $(PKG_SRC) $(VENDOR_SRC) $(KIPCTL_SRC)
 
 img: $(BINARIES)
 	@echo "Checking if IMAGE_TAG is set" && test -n "$(IMAGE_TAG)"
-	$(DKR) build -t $(REGISTRY_REPO):$(IMAGE_TAG) \
-		-t $(REGISTRY_REPO):$(IMAGE_DEV_OR_LATEST) .
+	$(DKR) build -t $(REGISTRY_REPO):$(IMAGE_TAG) .
 
 login-img:
 	@echo "Checking if REGISTRY_USER is set" && test -n "$(REGISTRY_USER)"
@@ -54,7 +48,6 @@ login-img:
 push-img: img
 	@echo "Checking if IMAGE_TAG is set" && test -n "$(IMAGE_TAG)"
 	$(DKR) push $(REGISTRY_REPO):$(IMAGE_TAG)
-	$(DKR) push $(REGISTRY_REPO):$(IMAGE_DEV_OR_LATEST)
 
 clean:
 	rm -f $(BINARIES)

--- a/scripts/init-cert/Dockerfile
+++ b/scripts/init-cert/Dockerfile
@@ -1,25 +1,27 @@
 FROM debian:stable-slim
 
-ARG K8S_VERSION_MAJOR
-RUN test -n "$K8S_VERSION_MAJOR"
-ARG K8S_VERSION_MINOR
-RUN test -n "$K8S_VERSION_MINOR"
+ARG K8S_VERSIONS
+RUN test -n "$K8S_VERSIONS"
 
 ENV DEBIAN_FRONTEND "noninteractive"
 
 RUN apt-get update -y && \
         apt-get dist-upgrade -y && \
-        apt-get install -y curl gettext-base iproute2 openssl
-
-RUN mkdir -p /usr/local/bin
+        apt-get install -y curl gettext-base iproute2 jq openssl
 
 RUN set -e; \
-    echo "installing kubectl for kubernetes ${K8S_VERSION_MAJOR}.${K8S_VERSION_MINOR}"; \
-    vsn=$(curl -fL https://storage.googleapis.com/kubernetes-release/release/stable-${K8S_VERSION_MAJOR}.${K8S_VERSION_MINOR}.txt); \
-    curl -fL https://storage.googleapis.com/kubernetes-release/release/${vsn}/bin/linux/amd64/kubectl > /usr/local/bin/kubectl-${vsn}; \
-    chmod 755 /usr/local/bin/kubectl-${vsn}; \
-    ln -snf /usr/local/bin/kubectl-${vsn} /usr/local/bin/kubectl; \
-    echo "installed kubectl ${vsn}"
+    for k8s_version in ${K8S_VERSIONS}; do \
+        echo "installing kubectl for kubernetes ${k8s_version}"; \
+        vdir=/opt/kubectl/${k8s_version}; \
+        mkdir -p ${vdir}; \
+        vsn=$(curl -fL https://storage.googleapis.com/kubernetes-release/release/stable-${k8s_version}.txt); \
+        curl -fL https://storage.googleapis.com/kubernetes-release/release/${vsn}/bin/linux/amd64/kubectl > ${vdir}/kubectl; \
+        chmod 755 ${vdir}/kubectl; \
+        echo "installed kubectl ${vsn} in ${vdir}"; \
+    done
+
+RUN mkdir -p /usr/local/bin
+COPY kubectl.sh /usr/local/bin/kubectl
 
 RUN curl -fL https://github.com/ldx/token2kubeconfig/releases/download/v0.0.2/token2kubeconfig-amd64 > /usr/local/bin/token2kubeconfig
 RUN chmod +x /usr/local/bin/token2kubeconfig

--- a/scripts/init-cert/build.sh
+++ b/scripts/init-cert/build.sh
@@ -11,7 +11,11 @@ UPDATE_LATEST=${UPDATE_LATEST:-false}
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPT_DIR
 
-docker build -t ${REPO}:${TAG} --build-arg K8S_VERSIONS="1.14 1.15 1.16 1.17 1.18" .
+LATEST_K8S_VERSION=$(curl -fsL https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+LATEST_K8S_MINOR=$(echo $LATEST_K8S_VERSION | sed -r 's/^v([0-9]+)\.([0-9]+)\..*$/\2/')
+K8S_VERSIONS=$(seq -f '1.%g' -s ' ' 14 $LATEST_K8S_MINOR)
+
+docker build -t ${REPO}:${TAG} --build-arg K8S_VERSIONS="${K8S_VERSIONS}" .
 
 if $PUSH_IMAGES; then
     docker push ${REPO}:${TAG}

--- a/scripts/init-cert/build.sh
+++ b/scripts/init-cert/build.sh
@@ -2,14 +2,21 @@
 
 set -euxo pipefail
 
+TAG=${TAG:-$(git describe --dirty)}
 DKR=${DKR:-docker}
-PUSH_IMAGES=${PUSH_IMAGES:-false}
+REPO=${REPO:-elotl/init-cert}
+PUSH_IMAGES=${PUSH_IMAGES:-true}
+UPDATE_LATEST=${UPDATE_LATEST:-false}
 
-major=1
-for minor in $(seq 12 18); do
-    tag="k8s-${major}.${minor}"
-    docker build -t elotl/init-cert:${tag} --build-arg K8S_VERSION_MAJOR=${major} --build-arg K8S_VERSION_MINOR=${minor} .
-    $PUSH_IMAGES && docker push elotl/init-cert:${tag} || true
-done
-docker tag elotl/init-cert:k8s-1.18 elotl/init-cert:latest
-$PUSH_IMAGES && docker push elotl/init-cert:latest || true
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR
+
+docker build -t ${REPO}:${TAG} --build-arg K8S_VERSIONS="1.14 1.15 1.16 1.17 1.18" .
+
+if $PUSH_IMAGES; then
+    docker push ${REPO}:${TAG}
+    if $UPDATE_LATEST; then
+        docker tag ${REPO}:${TAG} ${REPO}:latest
+        docker push ${REPO}:latest
+    fi
+fi

--- a/scripts/init-cert/kubectl.sh
+++ b/scripts/init-cert/kubectl.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+kubectl_dir_base=/opt/kubectl
+default_kubectl=${kubectl_dir_base}/1.16/kubectl
+
+version_doc="$($default_kubectl version --output=json | jq -r '.serverVersion')"
+
+major_vsn=$(echo "$version_doc" | jq -r '.major' | sed -r 's/([0-9]+).*/\1/')
+minor_vsn=$(echo "$version_doc" | jq -r '.minor' | sed -r 's/([0-9]+).*/\1/')
+
+kubectl=$default_kubectl
+if [[ -d /opt/kubectl/${major_vsn}.${minor_vsn} ]]; then
+    kubectl=/opt/kubectl/${major_vsn}.${minor_vsn}/kubectl
+else
+    for kdir in ${kubectl_dir_base}/*; do
+        echo $kdir
+        vdir=$(basename ${kdir})
+        kdir_major=$(echo ${vdir} | sed -r 's/([0-9]+)\.([0-9]+)/\1/')
+        if [[ ${kdir_major} -ne ${major_vsn} ]]; then
+            continue
+        fi
+        kdir_minor=$(echo ${vdir} | sed -r 's/([0-9]+)\.([0-9]+)/\2/')
+        if [[ ${kdir_minor} -eq $((${minor_vsn}-1)) ]] || \
+            [[ ${kdir_minor} -eq $((${minor_vsn}+1)) ]]; then
+            kubectl=${kdir}/kubectl
+        fi
+    done
+fi
+
+echo "using $kubectl" 1>&2
+$kubectl "$@"

--- a/scripts/run_smoke_test.sh
+++ b/scripts/run_smoke_test.sh
@@ -36,8 +36,10 @@ cleanup() {
 
 update_vk() {
     local version="$(git describe)"
-    local patch="{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"image\":\"elotl/kip:$version\",\"name\":\"kip\"}]}}}}"
-    kubectl patch -n kube-system statefulset kip-provider -p "$patch"
+    local patch_init="{\"spec\":{\"template\":{\"spec\":{\"initContainers\":[{\"image\":\"elotl/init-cert:$version\",\"name\":\"init-cert\"}]}}}}"
+    local patch_kip="{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"image\":\"elotl/kip:$version\",\"name\":\"kip\"}]}}}}"
+    kubectl patch -n kube-system statefulset kip-provider -p "$patch_init"
+    kubectl patch -n kube-system statefulset kip-provider -p "$patch_kip"
 }
 
 run_smoke_test() {

--- a/scripts/update_latest_tags.sh
+++ b/scripts/update_latest_tags.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# This script is run by the build when all tests have passed. If we are on a
+# release tag, then it will update the :latest tags for elotl/kip and
+# elotl/init-cert.
+#
+
+set -exuo pipefail
+
+TAG=${TAG:-$(git describe --dirty)}
+DKR=${DKR:-docker}
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR=$SCRIPT_DIR/..
+cd $ROOT_DIR
+
+if [[ $TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)$ ]]; then
+    $DKR tag elotl/kip:$TAG elotl/kip:latest
+    $DKR tag elotl/init-cert:$TAG elotl/init-cert:latest
+fi


### PR DESCRIPTION
Changes:
- Build only one init-cert image, with all supported kubectl versions included. One that is compatible with the server is chosen during runtime.
- Have the build create and use an init-cert image, instead of pulling an existing one from the registry.
- If all tests pass, and the build is for a release tag in git, update the :latest tag for elotl/kip and elotl/init-cert.