### PR TITLE
updating docs and manifests for deploying into GCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ You can configure the AWS access key Kip will use in your provider configuration
 
 In AWS, Kip can use credentials supplied by the [instance profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) attached to the node the pod is dispatched to.  To use an instance profile, create an IAM policy with the [minimum Kip permissions](docs/kip-iam-permissions.md) then apply the instance profile to the node that will run the Kip provider pod.  The Kip pod must run on the cloud instance that the instance profile is attached to.
 
-**GCP Credentials Option 1 - Built-in instance service account:**
+**GCP Credentials Option 1 - instance service account:**
 
-In GCE, Kip can use the service account built into the instance.  Kip requires https://www.googleapis.com/auth/compute scope in order to launch instances.
+In GCE, Kip can use the service account attached to an instance.  Kip requires https://www.googleapis.com/auth/compute scope in order to launch instances.
 
 **GCP Credentials - Service Account private key:**
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,15 @@ Alternatively, Kip can use service account credentials manually supplied in prov
 
 The resources in [deploy/manifests/kip](deploy/manifests/kip) create ServiceAccounts, Roles and a StatefulSet to run the provider. [Kip is not stateless](docs/state.md), the manifest will also create a PersistentVolumeClaim to store the provider data.
 
-Once credentials are set up, apply [deploy/manifests/kip/base](deploy/manifests/kip/base) to create the necessary kubernetes resources to support and run the provider:
+Once credentials are set up, apply [deploy/manifests/kip/base](deploy/manifests/kip/base) to create the necessary kubernetes resources to support and run the provider.
+
+In AWS:
 
     $ kustomize build deploy/manifests/kip/base | kubectl apply -f -
+
+In GCE:
+
+    $ kustomize build deploy/manifests/kip/overlays/gcp | kubectl apply -f -
 
 For rendering the manifests, [kustomize](https://kustomize.io/) is used. You can create your own overlays on top of the base template. For example, to override provider.yaml, Kip's configuration file:
 

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ On Google Cloud, the config under `deploy/terraform-gcp` works in a similar way,
 
 ### Installation Option 2: Using an Existing Cluster
 
-To deploy Kip into an existing cluster, you'll need to setup cloud credentials that allow the Kip provider to manipulate cloud instances, security groups and other cloud resources.
+To deploy Kip into an existing cluster, you'll need to setup cloud credentials that allow the Kip provider to manipulate cloud instances, networking and other cloud resources.
 
 **Step 1: Credentials**
 
 In AWS, Kip can either use API keys supplied in the Kip provider configuration file (`provider.yaml`) or use the instance profile of the machine the Kip pod is running on.
 
-On Google Cloud, a service account key is used for authentication.
+On Google Cloud, Kip can use the oauth scopes attached to the k8s node it runs on.  Alternatively the user can supply a service account key in provider.yaml.
 
 **AWS Credentials Option 1 - Configuring AWS API keys:**
 
@@ -62,9 +62,13 @@ You can configure the AWS access key Kip will use in your provider configuration
 
 In AWS, Kip can use credentials supplied by the [instance profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) attached to the node the pod is dispatched to.  To use an instance profile, create an IAM policy with the [minimum Kip permissions](docs/kip-iam-permissions.md) then apply the instance profile to the node that will run the Kip provider pod.  The Kip pod must run on the cloud instance that the instance profile is attached to.
 
+**GCP Credentials Option 1 - Built-in instance service account:**
+
+In GCE, Kip can use the service account built into the instance.  Kip requires https://www.googleapis.com/auth/compute scope in order to launch instances.
+
 **GCP Credentials - Service Account private key:**
 
-Add your email and key to `cloud.gce.credentials`. Example:
+Alternatively, Kip can use service account credentials manually supplied in provider.yaml.  Add your email and key to `cloud.gce.credentials`. Example:
 
     cloud:
       gce:

--- a/deploy/manifests/kip/overlays/gcp/provider.yaml
+++ b/deploy/manifests/kip/overlays/gcp/provider.yaml
@@ -1,9 +1,13 @@
 apiVersion: v1
 cloud:
-  gce:
-    credentials:
-      clientEmail: FILL_IN
-      privateKey: FILL_IN
+  gce: {}
+    # if the k8s node where kip will run doesn't have
+    # https://www.googleapis.com/auth/compute scope then GCE
+    # credentials for kip can be supplied in cloud.gce.credentials:
+    #
+    # credentials:
+    #   clientEmail: FILL_IN
+    #   privateKey: FILL_IN
 etcd:
   internal:
     dataDir: /opt/kip/data

--- a/deploy/terraform-gcp/README.md
+++ b/deploy/terraform-gcp/README.md
@@ -10,17 +10,10 @@ You need:
 * kubectl >= 1.14
 * Terraform >= 0.12
 
-Create an overlay for deploying Kip:
-
-    cp -rf ../manifests/kip/overlays/gcp ../manifests/kip/overlays/local-my-gcp
-    # Fill in authentication details for your GCP project.
-    vi ../manifests/kip/overlays/local-my-gcp/provider.yaml
-
 You can then apply your config:
 
     cp env.tfvars.example myenv.tfvars
-    # Change kustomize-dir to ../manifests/kip/overlays/local-my-gcp
-    vi myenv.tfvars
+    vi myenv.tfvars # You can change settings for your cluster here.
     terraform apply -var-file myenv.tfvars
 
 This will create a new GKE cluster and deploy Kip:

--- a/deploy/terraform-gcp/variables.tf
+++ b/deploy/terraform-gcp/variables.tf
@@ -29,7 +29,7 @@ variable "service-cidr" {
 }
 
 variable "kustomize-dir" {
-  default     = "../manifests/kip/base"
+  default     = "../manifests/kip/overlays/gcp"
   description = "A kustomization directory that will be applied once the cluster is created. Leave it empty to disable."
 }
 

--- a/docs/provider-config.md
+++ b/docs/provider-config.md
@@ -47,8 +47,8 @@ cloud:
     # using instance metadata
     # projectID: "my-project"
 
-    # Kip can use the oauth scopes attached to the GCE instance it runs on.
-    # if the instance doesn't have the https://www.googleapis.com/auth/compute
+    # Kip can use the service account attached to the GCE instance it runs on.
+    # If the instance doesn't have the https://www.googleapis.com/auth/compute
     # scope attached then credentials for kip to launch instances can be
     # manually supplied via a clientEmail and service account private key
     # credentials:

--- a/docs/provider-config.md
+++ b/docs/provider-config.md
@@ -11,7 +11,7 @@ apiVersion: v1
 cloud:
 
   # Only one cloud provider can be enabled in kip. Currently
-  # only AWS is supported but we are working on support for
+  # AWS and GCE are supported. We are working on support for
   # Azure
 
   aws:
@@ -40,6 +40,32 @@ cloud:
     # blank, kip will detect its current subnet (via AWS metadata)
     # and will launch pods into that subnet.
     # subnetID: ''
+
+  # gce:
+
+    # The GCE project where kip will be running. Can be auto-detected
+    # using instance metadata
+    # projectID: "my-project"
+
+    # Kip can use the oauth scopes attached to the GCE instance it runs on.
+    # if the instance doesn't have the https://www.googleapis.com/auth/compute
+    # scope attached then credentials for kip to launch instances can be
+    # manually supplied via a clientEmail and service account private key
+    # credentials:
+      # clientEmail: my-account@my-project.iam.gserviceaccount.com
+      # privateKey: "-----BEGIN PRIVATE KEY-----\n[base64-encoded private key]-----END PRIVATE KEY-----\n"
+
+    # The zone where kip will run and launch instance into. Can be
+    # auto-detected using instance metadata.
+    # zone: us-central1-c
+
+    # The name of the virtual cloud network where kip will run. Can be
+    # auto-detected using instance metadata.
+    # vpcName: "default"
+
+    # The name of the subnet where kip will run and launch instance into.
+    # Can be auto-detected using instance metadata.
+    # subnetName: "default"
 
 # the etcd section controls how kip stores its state, either using
 # an external etcd cluster or using an embedded etcd database.

--- a/pkg/server/cloud/gce/network.go
+++ b/pkg/server/cloud/gce/network.go
@@ -56,7 +56,7 @@ func (c *gceClient) getVPCRegionCIDRs(vpcName string) ([]string, error) {
 	defer cancel()
 	resp, err := c.service.Networks.Get(c.projectID, vpcName).Context(ctx).Do()
 	if err != nil {
-		return nil, util.WrapError(err, "error querying VPC %s in GCP", vpcName)
+		return nil, util.WrapError(err, "error querying VPC %s in GCE", vpcName)
 	}
 	if resp == nil {
 		return nil, nilResponseError("Networks.Get")
@@ -172,7 +172,7 @@ func (c *gceClient) autodetectSubnet() (string, string, error) {
 		subnetCIDR := subnets[i].IpCidrRange
 		_, ipnet, err := net.ParseCIDR(subnetCIDR)
 		if err != nil {
-			return "", "", util.WrapError(err, "Could not parse CIDR returned from GCP API: %s", subnetCIDR)
+			return "", "", util.WrapError(err, "Could not parse CIDR returned from GCE API: %s", subnetCIDR)
 		}
 		if ipnet.Contains(ip) {
 			return subnets[i].Name, subnets[i].IpCidrRange, nil


### PR DESCRIPTION
Kip can use the service account credentials on its host instance. Updating manifests and docs to reflect this.

1. If deploying via terraform, change the default kustomize base to GCE and default to pulling credentials from the host instance.
2. If adding kip to an existing k8s cluster, update the docs to talk about 2 ways of authenticating (similar to AWS)

Also updated docs/provider-yaml.md to have a blurb about GCE cloud configuration.