### PR TITLE
Fetch GPG key from keyserver

### DIFF
--- a/deploy/terraform-aws/node.sh
+++ b/deploy/terraform-aws/node.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-curl -fL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6A030B21BA07F4FB
 cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF


### PR DESCRIPTION
Instead of fetching the key and then adding it to apt, which has been
flaky lately, fetch it from a keyserver. This should help with smoke
test flakyness.