### PR TITLE
allow user to specify endpointURL in provider.yaml. 

### DIFF
--- a/docs/provider-config.md
+++ b/docs/provider-config.md
@@ -41,6 +41,10 @@ cloud:
     # and will launch pods into that subnet.
     # subnetID: ''
 
+    # Specify a custom endpoint URL for AWS EC2 service/API requests
+    # this corresponds to the --endpoint-url option in the AWS CLI
+    # endpointURL: ''
+
   # gce:
 
     # The GCE project where kip will be running. Can be auto-detected

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -89,6 +89,7 @@ type AWSConfig struct {
 	VPCID           string `json:"vpcID,omitempty"`
 	SubnetID        string `json:"subnetID,omitempty"`
 	EcsClusterName  string `json:"ecsClusterName"`
+	EndpointURL     string `json:"endpointURL"`
 }
 
 // See https://github.com/Azure/azure-sdk-for-go/blob/master/README.md
@@ -238,7 +239,7 @@ func setupAwsEnvVars(c *AWSConfig) error {
 		}
 	}
 	klog.V(2).Infof("Validating connection to AWS")
-	if err := aws.CheckConnection(); err != nil {
+	if err := aws.CheckConnection(c.EndpointURL); err != nil {
 		return util.WrapError(err, "Error validationg connection to AWS")
 	}
 	klog.V(2).Infof("Validated access to AWS")


### PR DESCRIPTION
Addresses the point in issue in https://github.com/elotl/kip/issues/141.  Allow the user to specify a custom endpoint URL used by the ec2 client.  This overrides the default behavior of connecting to the endpoint at `protocol://service-code.region-code.amazonaws.com` (see: https://docs.aws.amazon.com/general/latest/gr/rande.html).

Also get rid of the unused AWS ELB Client (from the old Milpa days).