### PR TITLE
Use k8s-style escaped envvar in manifest

### DIFF
--- a/deploy/manifests/kip/base/statefulset.yaml
+++ b/deploy/manifests/kip/base/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
       - command:
         - bash
         - -c
-        - mkdir -p $CERT_DIR && /opt/csr/get-cert.sh
+        - mkdir -p $(CERT_DIR) && /opt/csr/get-cert.sh
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
If a user pipes the generated manifests through envsubst, then any un-escaped variable will be substituted. I changed the statefulset manifest to use Kubernetes-style escaping to prevent it.