### PR TITLE
Autodetect AWS region

### DIFF
--- a/pkg/server/cloud/aws/aws.go
+++ b/pkg/server/cloud/aws/aws.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -96,6 +97,22 @@ func getECSClient(endpointURL string, insecureSkipSSLVerify bool) (*ecs.ECS, err
 	config := getAWSConfig(endpointURL, insecureSkipSSLVerify)
 	client := ecs.New(sess, config)
 	return client, nil
+}
+
+func AutoDetectRegion() string {
+	session, err := session.NewSession()
+	if err != nil {
+		klog.Warningf("creating session to autodetect AWS region: %v", err)
+		return ""
+	}
+	client := ec2metadata.New(session)
+	region, err := client.Region()
+	if err != nil {
+		klog.Warningf("trying to autodetect AWS region: %v", err)
+		return ""
+	}
+	klog.V(2).Infof("detected AWS region: %q", region)
+	return region
 }
 
 func CheckConnection(endpointURL string, insecureSkipSSLVerify bool) error {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -224,6 +224,7 @@ func setupAWSRegion(configRegion string) error {
 	if os.Getenv("AWS_DEFAULT_REGION") != "" {
 		winningRegionVal = os.Getenv("AWS_DEFAULT_REGION")
 	}
+	klog.V(2).Infof("using AWS region %q", winningRegionVal)
 	return os.Setenv("AWS_REGION", winningRegionVal)
 }
 
@@ -234,8 +235,12 @@ func setupAwsEnvVars(c *AWSConfig) error {
 	if err := setEnvIfNotSet("AWS_SECRET_ACCESS_KEY", c.SecretAccessKey); err != nil {
 		return err
 	}
-	if c.Region != "" {
-		if err := setupAWSRegion(c.Region); err != nil {
+	region := c.Region
+	if region == "" {
+		region = aws.AutoDetectRegion()
+	}
+	if region != "" {
+		if err := setupAWSRegion(region); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This helps if Kip is running inside a VPC. In the basic case, now the user can simply use:

    cloud:
      aws: {}

in their provider.yaml.