### PR TITLE
Add cells.defaultIAMPermissions to provider.yaml

### DIFF
--- a/docs/provider-config.md
+++ b/docs/provider-config.md
@@ -127,6 +127,12 @@ cells:
   # value as "8Gi".  Must be 1Gi or larger, defaults to 5Gi.
   defaultVolumeSize: "5Gi"
 
+  # defaultIAMPermissions specifies the a cloud-specific IAM permission that
+  # will be attached to cell instances. On AWS, this is an IAM instance
+  # profile, and can be overridden by the pod.elotl.co/instance-profile pod
+  # annotation.
+  #defaultIAMPermissions: "arn:aws:iam::11123456789:instance-profile/kip-cell"
+
   # bootImageSpec is a dictionary of cloud-specific image properties for
   # specifying the boot image to use for cells.
   # Valid fields on AWS are:

--- a/pkg/server/cloud/aws/instances.go
+++ b/pkg/server/cloud/aws/instances.go
@@ -606,7 +606,7 @@ func isUnsupportedInstanceError(err error) bool {
 // UnsupportedInstanceAttribute, UnsupportedOperation
 // InvalidAvailabilityZone
 
-func (e *AwsEC2) AssignInstanceProfile(node *api.Node, instanceProfile string) error {
+func (e *AwsEC2) AddIAMPermissions(node *api.Node, instanceProfile string) error {
 	_, err := e.client.AssociateIamInstanceProfile(
 		&ec2.AssociateIamInstanceProfileInput{
 			IamInstanceProfile: &ec2.IamInstanceProfileSpecification{

--- a/pkg/server/cloud/azure/instances.go
+++ b/pkg/server/cloud/azure/instances.go
@@ -566,6 +566,6 @@ func isUnsupportedInstanceError(err error) bool {
 	return strings.Contains(err.Error(), "SkuNotAvailable")
 }
 
-func (az *AzureClient) AssignInstanceProfile(node *api.Node, instanceProfile string) error {
+func (az *AzureClient) AddIAMPermissions(node *api.Node, permissions string) error {
 	return nil
 }

--- a/pkg/server/cloud/cloud.go
+++ b/pkg/server/cloud/cloud.go
@@ -49,7 +49,7 @@ type CloudClient interface {
 	WaitForRunning(node *api.Node) ([]api.NetworkAddress, error)
 	EnsureMilpaSecurityGroups([]string, []string) error
 	AttachSecurityGroups(node *api.Node, groups []string) error
-	AssignInstanceProfile(node *api.Node, instanceProfile string) error
+	AddIAMPermissions(node *api.Node, permissions string) error
 	ListInstancesFilterID([]string) ([]CloudInstance, error)
 	ListInstances() ([]CloudInstance, error)
 	ResizeVolume(node *api.Node, size int64) (error, bool)

--- a/pkg/server/cloud/gce/instances.go
+++ b/pkg/server/cloud/gce/instances.go
@@ -540,7 +540,7 @@ func (c *gceClient) GetImage(spec cloud.BootImageSpec) (cloud.Image, error) {
 	}, nil
 }
 
-func (c *gceClient) AssignInstanceProfile(node *api.Node, instanceProfile string) error {
+func (c *gceClient) AddIAMPermissions(node *api.Node, permissions string) error {
 	klog.Errorf("In GCE Instances must be stopped to assign service account")
 	return nil
 }

--- a/pkg/server/cloud/mock.go
+++ b/pkg/server/cloud/mock.go
@@ -215,7 +215,7 @@ func (m *MockCloudClient) AttachSecurityGroups(node *api.Node, groups []string) 
 	return nil
 }
 
-func (m *MockCloudClient) AssignInstanceProfile(node *api.Node, instanceProfile string) error {
+func (m *MockCloudClient) AddIAMPermissions(node *api.Node, permissions string) error {
 	return nil
 }
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -138,19 +138,20 @@ type InternalEtcdConfig struct {
 }
 
 type CellsConfig struct {
-	BootImageSpec       cloud.BootImageSpec           `json:"bootImageSpec"`
-	DefaultInstanceType string                        `json:"defaultInstanceType"`
-	DefaultVolumeSize   string                        `json:"defaultVolumeSize"`
-	StandbyCells        []nodemanager.StandbyNodeSpec `json:"standbyCells"`
-	CloudInitFile       string                        `json:"cloudInitFile"`
-	Itzo                ItzoConfig                    `json:"itzo"`
-	ExtraCIDRs          []string                      `json:"extraCIDRs"`
-	ExtraSecurityGroups []string                      `json:"extraSecurityGroups"`
-	Nametag             string                        `json:"nametag"`
-	StatusInterval      int                           `json:"statusInterval"`
-	HealthCheck         HealthCheckConfig             `json:"healthcheck"`
-	PrivateIPOnly       *bool                         `json:"privateIPOnly"`
-	CellConfig          map[string]string             `json:"cellConfig"`
+	BootImageSpec         cloud.BootImageSpec           `json:"bootImageSpec"`
+	DefaultInstanceType   string                        `json:"defaultInstanceType"`
+	DefaultVolumeSize     string                        `json:"defaultVolumeSize"`
+	StandbyCells          []nodemanager.StandbyNodeSpec `json:"standbyCells"`
+	CloudInitFile         string                        `json:"cloudInitFile"`
+	Itzo                  ItzoConfig                    `json:"itzo"`
+	ExtraCIDRs            []string                      `json:"extraCIDRs"`
+	ExtraSecurityGroups   []string                      `json:"extraSecurityGroups"`
+	Nametag               string                        `json:"nametag"`
+	StatusInterval        int                           `json:"statusInterval"`
+	HealthCheck           HealthCheckConfig             `json:"healthcheck"`
+	PrivateIPOnly         *bool                         `json:"privateIPOnly"`
+	CellConfig            map[string]string             `json:"cellConfig"`
+	DefaultIAMPermissions string                        `json:"defaultIAMPermissions"`
 }
 
 type HealthCheckConfig struct {

--- a/pkg/server/pod_controller.go
+++ b/pkg/server/pod_controller.go
@@ -487,16 +487,16 @@ func (c *PodController) dispatchPodToNode(pod *api.Pod, node *api.Node) {
 		}
 	}
 
-	instanceProfile := pod.Annotations[annotations.PodInstanceProfile]
-	if len(instanceProfile) == 0 {
+	permissions := pod.Annotations[annotations.PodInstanceProfile]
+	if len(permissions) == 0 {
 		// This is called defaultIAMPermissions, and the semantics are
 		// cloud-specific. For example, on AWS this is an IAM instance profile.
-		instanceProfile = c.defaultIAMPermissions
+		permissions = c.defaultIAMPermissions
 	}
-	if len(instanceProfile) != 0 {
-		err := c.cloudClient.AssignInstanceProfile(node, instanceProfile)
+	if len(permissions) != 0 {
+		err := c.cloudClient.AddIAMPermissions(node, permissions)
 		if err != nil {
-			msg := fmt.Sprintf("Error dispatching pod to node, could not assign instance profile %s to pod %s: %s", instanceProfile, pod.Name, err)
+			msg := fmt.Sprintf("Error dispatching pod to node, could not add IAM permissions %s to pod %s: %s", permissions, pod.Name, err)
 			klog.Errorln(msg)
 			c.markFailedPod(pod, true, msg)
 			return

--- a/pkg/server/pod_controller.go
+++ b/pkg/server/pod_controller.go
@@ -79,6 +79,7 @@ type PodController struct {
 	dnsConfigurer          *dns.Configurer
 	statusInterval         time.Duration
 	healthChecker          *healthcheck.HealthCheckController
+	defaultIAMPermissions  string
 }
 
 type FullPodStatus struct {
@@ -487,6 +488,11 @@ func (c *PodController) dispatchPodToNode(pod *api.Pod, node *api.Node) {
 	}
 
 	instanceProfile := pod.Annotations[annotations.PodInstanceProfile]
+	if len(instanceProfile) == 0 {
+		// This is called defaultIAMPermissions, and the semantics are
+		// cloud-specific. For example, on AWS this is an IAM instance profile.
+		instanceProfile = c.defaultIAMPermissions
+	}
 	if len(instanceProfile) != 0 {
 		err := c.cloudClient.AssignInstanceProfile(node, instanceProfile)
 		if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -340,6 +340,7 @@ func NewInstanceProvider(configFilePath, nodeName, internalIP, serverURL, networ
 		networkAgentKubeconfig: networkAgentKubeconfig,
 		statusInterval:         time.Duration(serverConfigFile.Cells.StatusInterval) * time.Second,
 		healthChecker:          healthChecker,
+		defaultIAMPermissions:  serverConfigFile.Cells.DefaultIAMPermissions,
 	}
 
 	klog.V(5).Infof("creating image ID cache")


### PR DESCRIPTION
In provider.yaml, cells.defaultIAMPermissions specifies the a cloud-specific IAM permission that will be added to cell instances. On AWS, this is an IAM instance profile, and can be overridden by the pod.elotl.co/instance-profile pod annotation.