### PR TITLE
Fix terraform warning from deploy/terraform-aws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,7 @@ cmd/kip/kip
 /kipctl
 staticcheck.conf
 kubeconfig
-*.tfstate
-*.tfstate.backup
+*.tfstate.*
 *.tfvars
 deploy/terraform/.terraform/
 deploy/terraform-gcp/.terraform/

--- a/deploy/terraform-aws/env.tfvars.example
+++ b/deploy/terraform-aws/env.tfvars.example
@@ -26,8 +26,8 @@
 #  Size of the root device volume in GB on the node. E.g. "20"
 #node-disk-size = ""
 
-# Blacklist certain AZs to prevent capacity problems. E.g. ["use1-az3"]
-#blacklisted-azs = ""
+# Exclude certain AZs to prevent capacity problems. E.g. ["use1-az3"]
+#excluded-azs = ""
 
 # If not set, Ubuntu 16.04 will be used.
 #node-ami = ""

--- a/deploy/terraform-aws/main.tf
+++ b/deploy/terraform-aws/main.tf
@@ -1,5 +1,26 @@
+terraform {
+  required_version = ">= 0.12.0"
+}
+
+provider "external" {
+  version = "~> 1.2"
+}
+
+provider "random" {
+  version = "~> 2.3"
+}
+
+provider "template" {
+  version = "~> 2.1"
+}
+
+provider "tls" {
+  version = "~> 2.2"
+}
+
 provider "aws" {
-  region = var.region
+  version = "~> 3.0"
+  region  = var.region
 }
 
 locals {
@@ -10,8 +31,8 @@ locals {
 }
 
 data "aws_availability_zones" "available-azs" {
-  state                = "available"
-  exclude_zone_ids = var.blacklisted-azs
+  state             = "available"
+  exclude_zone_ids  = var.excluded-azs
 }
 
 resource "random_shuffle" "azs" {

--- a/deploy/terraform-aws/main.tf
+++ b/deploy/terraform-aws/main.tf
@@ -11,7 +11,7 @@ locals {
 
 data "aws_availability_zones" "available-azs" {
   state                = "available"
-  blacklisted_zone_ids = var.blacklisted-azs
+  exclude_zone_ids = var.blacklisted-azs
 }
 
 resource "random_shuffle" "azs" {

--- a/deploy/terraform-aws/variables.tf
+++ b/deploy/terraform-aws/variables.tf
@@ -30,7 +30,7 @@ variable "node-disk-size" {
   default = 15
 }
 
-variable "blacklisted-azs" {
+variable "excluded-azs" {
   type    = list(string)
   default = ["use1-az3"]
 }

--- a/deploy/terraform-gcp/main.tf
+++ b/deploy/terraform-gcp/main.tf
@@ -1,4 +1,17 @@
+terraform {
+  required_version = ">= 0.12.0"
+}
+
+provider "null" {
+  version =  "~> 2.1"
+}
+
+provider "random" {
+  version =  "~> 2.2"
+}
+
 provider "google" {
+  version = "~> 3.21"
   project = var.project
   region  = var.region
   zone    = var.zone

--- a/deploy/terraform-vpn/main.tf
+++ b/deploy/terraform-vpn/main.tf
@@ -1,5 +1,22 @@
+terraform {
+  required_version = ">= 0.12.0"
+}
+
+provider "http" {
+  version = "~> 1.2"
+}
+
+provider "local" {
+  version = "~> 1.4"
+}
+
+provider "null" {
+  version = "~> 2.1"
+}
+
 provider "aws" {
-  region = var.region
+  version = "~> 2.53"
+  region  = var.region
 }
 
 data "http" "client_ip" {


### PR DESCRIPTION
Fix[ issue 153](https://github.com/elotl/kip/issues/153).

Testing done: ran `terraform apply` and `terraform destroy` with the fix and did not see the warning.

```
$ terraform destroy -var-file myenv.tfvars 
data.external.manifest: Refreshing state...
random_id.k8stoken-suffix: Refreshing state... [id=MX9JLw3fzGc]
random_id.k8stoken-prefix: Refreshing state... [id=3IUc]
data.template_file.node-userdata: Refreshing state...
data.aws_availability_zones.available-azs: Refreshing state...
aws_vpc.main: Refreshing state... [id=vpc-0f1c0e5960fe4f403]
aws_iam_role.k8s-node: Refreshing state... [id=k8s-node-myechuri-argo-cluster]
data.aws_ami.ubuntu: Refreshing state...
aws_iam_instance_profile.k8s-node: Refreshing state... [id=k8s-node-myechuri-argo-cluster]
aws_iam_role_policy.k8s-node: Refreshing state... [id=k8s-node-myechuri-argo-cluster:k8s-node-myechuri-argo-cluster]
random_shuffle.azs: Refreshing state... [id=-]
aws_subnet.subnet: Refreshing state... [id=subnet-0ed75df3e4564478d]
aws_internet_gateway.gw: Refreshing state... [id=igw-04e635aa5a5d0cfd1]
aws_security_group.kubernetes: Refreshing state... [id=sg-031f663a0530b4d25]
aws_route_table.route-table: Refreshing state... [id=rtb-0e374d0f30b32f29e]
aws_instance.k8s-node: Refreshing state... [id=i-09f6a2a1dc6f5c4ce]
aws_route_table_association.route-table-to-subnet: Refreshing state... [id=rtbassoc-060171d0479a82ef0]

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # aws_iam_instance_profile.k8s-node will be destroyed
  - resource "aws_iam_instance_profile" "k8s-node" {
      - arn         = "arn:aws:iam::689494258501:instance-profile/k8s-node-myechuri-argo-cluster" -> null
      - create_date = "2020-07-13T22:36:54Z" -> null
      - id          = "k8s-node-myechuri-argo-cluster" -> null
      - name        = "k8s-node-myechuri-argo-cluster" -> null
      - path        = "/" -> null
      - role        = "k8s-node-myechuri-argo-cluster" -> null
      - roles       = [
          - "k8s-node-myechuri-argo-cluster",
        ] -> null
      - unique_id   = "AIPA2BCIPONC43MJQVAPS" -> null
    }

  # aws_iam_role.k8s-node will be destroyed
  - resource "aws_iam_role" "k8s-node" {
      - arn                   = "arn:aws:iam::689494258501:role/k8s-node-myechuri-argo-cluster" -> null
      - assume_role_policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "sts:AssumeRole"
                      - Effect    = "Allow"
                      - Principal = {
                          - Service = "ec2.amazonaws.com"
                        }
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - create_date           = "2020-07-13T22:36:53Z" -> null
      - force_detach_policies = false -> null
      - id                    = "k8s-node-myechuri-argo-cluster" -> null
      - max_session_duration  = 3600 -> null
      - name                  = "k8s-node-myechuri-argo-cluster" -> null
      - path                  = "/" -> null
      - tags                  = {
          - "Name"                                        = "myechuri-argo-cluster"
          - "kubernetes.io/cluster/myechuri-argo-cluster" = "owned"
        } -> null
      - unique_id             = "AROA2BCIPONC4B72CZWY7" -> null
    }

  # aws_iam_role_policy.k8s-node will be destroyed
  - resource "aws_iam_role_policy" "k8s-node" {
      - id     = "k8s-node-myechuri-argo-cluster:k8s-node-myechuri-argo-cluster" -> null
      - name   = "k8s-node-myechuri-argo-cluster" -> null
      - policy = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = [
                          - "autoscaling:DescribeAutoScalingGroups",
                          - "autoscaling:DescribeLaunchConfigurations",
                          - "autoscaling:DescribeTags",
                          - "ec2:AssignPrivateIpAddresses",
                          - "ec2:AttachNetworkInterface",
                          - "ec2:AttachVolume",
                          - "ec2:AuthorizeSecurityGroupIngress",
                          - "ec2:CreateNetworkInterface",
                          - "ec2:CreateRoute",
                          - "ec2:CreateSecurityGroup",
                          - "ec2:CreateTags",
                          - "ec2:CreateVolume",
                          - "ec2:DeleteNetworkInterface",
                          - "ec2:DeleteRoute",
                          - "ec2:DeleteSecurityGroup",
                          - "ec2:DeleteVolume",
                          - "ec2:DescribeAddresses",
                          - "ec2:DescribeAvailabilityZones",
                          - "ec2:DescribeDhcpOptions",
                          - "ec2:DescribeElasticGpus",
                          - "ec2:DescribeImages",
                          - "ec2:DescribeInstances",
                          - "ec2:DescribeNetworkInterfaces",
                          - "ec2:DescribeRegions",
                          - "ec2:DescribeRouteTables",
                          - "ec2:DescribeSecurityGroups",
                          - "ec2:DescribeSpotPriceHistory",
                          - "ec2:DescribeSubnets",
                          - "ec2:DescribeTags",
                          - "ec2:DescribeVolumes",
                          - "ec2:DescribeVpcAttribute",
                          - "ec2:DescribeVpcs",
                          - "ec2:DetachNetworkInterface",
                          - "ec2:DetachVolume",
                          - "ec2:ModifyInstanceAttribute",
                          - "ec2:ModifyInstanceCreditSpecification",
                          - "ec2:ModifyNetworkInterfaceAttribute",
                          - "ec2:ModifyVolume",
                          - "ec2:ModifyVpcAttribute",
                          - "ec2:RequestSpotInstances",
                          - "ec2:RevokeSecurityGroupIngress",
                          - "ec2:RunInstances",
                          - "ec2:TerminateInstances",
                          - "ec2:UnassignPrivateIpAddresses",
                          - "ecr:BatchCheckLayerAvailability",
                          - "ecr:BatchGetImage",
                          - "ecr:DescribeRepositories",
                          - "ecr:GetAuthorizationToken",
                          - "ecr:GetDownloadUrlForLayer",
                          - "ecr:GetRepositoryPolicy",
                          - "ecr:ListImages",
                          - "ecs:CreateCluster",
                          - "ecs:DeregisterTaskDefinition",
                          - "ecs:DescribeClusters",
                          - "ecs:DescribeTasks",
                          - "ecs:ListAccountSettings",
                          - "ecs:ListTaskDefinitions",
                          - "ecs:ListTasks",
                          - "ecs:PutAccountSetting",
                          - "ecs:RegisterTaskDefinition",
                          - "ecs:RunTask",
                          - "ecs:StopTask",
                          - "elasticloadbalancing:AddTags",
                          - "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
                          - "elasticloadbalancing:AttachLoadBalancerToSubnets",
                          - "elasticloadbalancing:ConfigureHealthCheck",
                          - "elasticloadbalancing:CreateListener",
                          - "elasticloadbalancing:CreateLoadBalancer",
                          - "elasticloadbalancing:CreateLoadBalancerListeners",
                          - "elasticloadbalancing:CreateLoadBalancerPolicy",
                          - "elasticloadbalancing:CreateTargetGroup",
                          - "elasticloadbalancing:DeleteListener",
                          - "elasticloadbalancing:DeleteLoadBalancer",
                          - "elasticloadbalancing:DeleteLoadBalancerListeners",
                          - "elasticloadbalancing:DeleteTargetGroup",
                          - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
                          - "elasticloadbalancing:DescribeListeners",
                          - "elasticloadbalancing:DescribeLoadBalancerAttributes",
                          - "elasticloadbalancing:DescribeLoadBalancerPolicies",
                          - "elasticloadbalancing:DescribeLoadBalancers",
                          - "elasticloadbalancing:DescribeTargetGroups",
                          - "elasticloadbalancing:DescribeTargetHealth",
                          - "elasticloadbalancing:DetachLoadBalancerFromSubnets",
                          - "elasticloadbalancing:ModifyListener",
                          - "elasticloadbalancing:ModifyLoadBalancerAttributes",
                          - "elasticloadbalancing:ModifyTargetGroup",
                          - "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
                          - "elasticloadbalancing:RegisterTargets",
                          - "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer",
                          - "elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
                          - "iam:CreateServiceLinkedRole",
                          - "kms:DescribeKey",
                        ]
                      - Effect   = "Allow"
                      - Resource = [
                          - "*",
                        ]
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - role   = "k8s-node-myechuri-argo-cluster" -> null
    }

  # aws_instance.k8s-node will be destroyed
  - resource "aws_instance" "k8s-node" {
      - ami                          = "ami-0dc45e3d9be6ab7b5" -> null
      - arn                          = "arn:aws:ec2:us-east-1:689494258501:instance/i-09f6a2a1dc6f5c4ce" -> null
      - associate_public_ip_address  = true -> null
      - availability_zone            = "us-east-1c" -> null
      - cpu_core_count               = 1 -> null
      - cpu_threads_per_core         = 2 -> null
      - disable_api_termination      = false -> null
      - ebs_optimized                = false -> null
      - get_password_data            = false -> null
      - hibernation                  = false -> null
      - iam_instance_profile         = "k8s-node-myechuri-argo-cluster" -> null
      - id                           = "i-09f6a2a1dc6f5c4ce" -> null
      - instance_state               = "running" -> null
      - instance_type                = "t3.medium" -> null
      - ipv6_address_count           = 0 -> null
      - ipv6_addresses               = [] -> null
      - key_name                     = "myechuri-key2" -> null
      - monitoring                   = false -> null
      - primary_network_interface_id = "eni-0ccf1c5d1d046f9cd" -> null
      - private_dns                  = "ip-10-0-23-102.ec2.internal" -> null
      - private_ip                   = "10.0.23.102" -> null
      - public_dns                   = "ec2-18-234-89-217.compute-1.amazonaws.com" -> null
      - public_ip                    = "18.234.89.217" -> null
      - security_groups              = [] -> null
      - source_dest_check            = false -> null
      - subnet_id                    = "subnet-0ed75df3e4564478d" -> null
      - tags                         = {
          - "Name"                                        = "myechuri-argo-cluster-node"
          - "kubernetes.io/cluster/myechuri-argo-cluster" = "owned"
        } -> null
      - tenancy                      = "default" -> null
      - user_data                    = "aff74d8bc09d153127b7bb8e7251eeaa4d8914a1" -> null
      - volume_tags                  = {
          - "Name"                                        = "kubernetes-dynamic-pvc-99bc9ebe-40a6-4217-9074-156e142ac8bb"
          - "kubernetes.io/cluster/myechuri-argo-cluster" = "owned"
          - "kubernetes.io/created-for/pv/name"           = "pvc-99bc9ebe-40a6-4217-9074-156e142ac8bb"
          - "kubernetes.io/created-for/pvc/name"          = "data-kip-provider-0"
          - "kubernetes.io/created-for/pvc/namespace"     = "kube-system"
        } -> null
      - vpc_security_group_ids       = [
          - "sg-031f663a0530b4d25",
        ] -> null

      - credit_specification {
          - cpu_credits = "unlimited" -> null
        }

      - ebs_block_device {
          - delete_on_termination = false -> null
          - device_name           = "/dev/xvdce" -> null
          - encrypted             = false -> null
          - iops                  = 100 -> null
          - volume_id             = "vol-0784f295183e2802d" -> null
          - volume_size           = 4 -> null
          - volume_type           = "gp2" -> null
        }

      - metadata_options {
          - http_endpoint               = "enabled" -> null
          - http_put_response_hop_limit = 1 -> null
          - http_tokens                 = "optional" -> null
        }

      - root_block_device {
          - delete_on_termination = true -> null
          - device_name           = "/dev/sda1" -> null
          - encrypted             = false -> null
          - iops                  = 100 -> null
          - volume_id             = "vol-096bb31740bba96ef" -> null
          - volume_size           = 15 -> null
          - volume_type           = "gp2" -> null
        }
    }

  # aws_internet_gateway.gw will be destroyed
  - resource "aws_internet_gateway" "gw" {
      - arn      = "arn:aws:ec2:us-east-1:689494258501:internet-gateway/igw-04e635aa5a5d0cfd1" -> null
      - id       = "igw-04e635aa5a5d0cfd1" -> null
      - owner_id = "689494258501" -> null
      - tags     = {
          - "Name"                                        = "myechuri-argo-cluster"
          - "kubernetes.io/cluster/myechuri-argo-cluster" = "owned"
        } -> null
      - vpc_id   = "vpc-0f1c0e5960fe4f403" -> null
    }

  # aws_route_table.route-table will be destroyed
  - resource "aws_route_table" "route-table" {
      - id               = "rtb-0e374d0f30b32f29e" -> null
      - owner_id         = "689494258501" -> null
      - propagating_vgws = [] -> null
      - route            = [
          - {
              - cidr_block                = "0.0.0.0/0"
              - egress_only_gateway_id    = ""
              - gateway_id                = "igw-04e635aa5a5d0cfd1"
              - instance_id               = ""
              - ipv6_cidr_block           = ""
              - nat_gateway_id            = ""
              - network_interface_id      = ""
              - transit_gateway_id        = ""
              - vpc_peering_connection_id = ""
            },
        ] -> null
      - tags             = {
          - "Name"                                        = "myechuri-argo-cluster"
          - "kubernetes.io/cluster/myechuri-argo-cluster" = "owned"
        } -> null
      - vpc_id           = "vpc-0f1c0e5960fe4f403" -> null
    }

  # aws_route_table_association.route-table-to-subnet will be destroyed
  - resource "aws_route_table_association" "route-table-to-subnet" {
      - id             = "rtbassoc-060171d0479a82ef0" -> null
      - route_table_id = "rtb-0e374d0f30b32f29e" -> null
      - subnet_id      = "subnet-0ed75df3e4564478d" -> null
    }

  # aws_security_group.kubernetes will be destroyed
  - resource "aws_security_group" "kubernetes" {
      - arn                    = "arn:aws:ec2:us-east-1:689494258501:security-group/sg-031f663a0530b4d25" -> null
      - description            = "Main kubernetes security group" -> null
      - egress                 = [
          - {
              - cidr_blocks      = [
                  - "0.0.0.0/0",
                ]
              - description      = ""
              - from_port        = 0
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "-1"
              - security_groups  = []
              - self             = false
              - to_port          = 0
            },
        ] -> null
      - id                     = "sg-031f663a0530b4d25" -> null
      - ingress                = [
          - {
              - cidr_blocks      = [
                  - "0.0.0.0/0",
                ]
              - description      = ""
              - from_port        = 22
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "tcp"
              - security_groups  = []
              - self             = false
              - to_port          = 22
            },
          - {
              - cidr_blocks      = [
                  - "10.0.0.0/16",
                ]
              - description      = ""
              - from_port        = 0
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "-1"
              - security_groups  = []
              - self             = false
              - to_port          = 0
            },
          - {
              - cidr_blocks      = [
                  - "172.20.0.0/16",
                ]
              - description      = ""
              - from_port        = 0
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "-1"
              - security_groups  = []
              - self             = false
              - to_port          = 0
            },
        ] -> null
      - name                   = "kubernetes" -> null
      - owner_id               = "689494258501" -> null
      - revoke_rules_on_delete = false -> null
      - tags                   = {
          - "Name"                                        = "myechuri-argo-cluster"
          - "kubernetes.io/cluster/myechuri-argo-cluster" = "owned"
        } -> null
      - vpc_id                 = "vpc-0f1c0e5960fe4f403" -> null
    }

  # aws_subnet.subnet will be destroyed
  - resource "aws_subnet" "subnet" {
      - arn                             = "arn:aws:ec2:us-east-1:689494258501:subnet/subnet-0ed75df3e4564478d" -> null
      - assign_ipv6_address_on_creation = false -> null
      - availability_zone               = "us-east-1c" -> null
      - availability_zone_id            = "use1-az6" -> null
      - cidr_block                      = "10.0.16.0/20" -> null
      - id                              = "subnet-0ed75df3e4564478d" -> null
      - map_public_ip_on_launch         = true -> null
      - owner_id                        = "689494258501" -> null
      - tags                            = {
          - "Name"                                        = "myechuri-argo-cluster"
          - "kubernetes.io/cluster/myechuri-argo-cluster" = "owned"
        } -> null
      - vpc_id                          = "vpc-0f1c0e5960fe4f403" -> null
    }

  # aws_vpc.main will be destroyed
  - resource "aws_vpc" "main" {
      - arn                              = "arn:aws:ec2:us-east-1:689494258501:vpc/vpc-0f1c0e5960fe4f403" -> null
      - assign_generated_ipv6_cidr_block = false -> null
      - cidr_block                       = "10.0.0.0/16" -> null
      - default_network_acl_id           = "acl-0f074eca8d8d22e67" -> null
      - default_route_table_id           = "rtb-0b8281aefc7745340" -> null
      - default_security_group_id        = "sg-014909729531ee56a" -> null
      - dhcp_options_id                  = "dopt-434a7d24" -> null
      - enable_classiclink               = false -> null
      - enable_classiclink_dns_support   = false -> null
      - enable_dns_hostnames             = true -> null
      - enable_dns_support               = true -> null
      - id                               = "vpc-0f1c0e5960fe4f403" -> null
      - instance_tenancy                 = "default" -> null
      - main_route_table_id              = "rtb-0b8281aefc7745340" -> null
      - owner_id                         = "689494258501" -> null
      - tags                             = {
          - "Name"                                        = "myechuri-argo-cluster"
          - "kubernetes.io/cluster/myechuri-argo-cluster" = "owned"
        } -> null
    }

  # random_id.k8stoken-prefix will be destroyed
  - resource "random_id" "k8stoken-prefix" {
      - b64         = "3IUc" -> null
      - b64_std     = "3IUc" -> null
      - b64_url     = "3IUc" -> null
      - byte_length = 3 -> null
      - dec         = "14451996" -> null
      - hex         = "dc851c" -> null
      - id          = "3IUc" -> null
    }

  # random_id.k8stoken-suffix will be destroyed
  - resource "random_id" "k8stoken-suffix" {
      - b64         = "MX9JLw3fzGc" -> null
      - b64_std     = "MX9JLw3fzGc=" -> null
      - b64_url     = "MX9JLw3fzGc" -> null
      - byte_length = 8 -> null
      - dec         = "3566649896345783399" -> null
      - hex         = "317f492f0ddfcc67" -> null
      - id          = "MX9JLw3fzGc" -> null
    }

  # random_shuffle.azs will be destroyed
  - resource "random_shuffle" "azs" {
      - id           = "-" -> null
      - input        = [
          - "us-east-1a",
          - "us-east-1b",
          - "us-east-1c",
          - "us-east-1d",
          - "us-east-1f",
        ] -> null
      - result       = [
          - "us-east-1c",
        ] -> null
      - result_count = 1 -> null
    }

Plan: 0 to add, 0 to change, 13 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

aws_route_table_association.route-table-to-subnet: Destroying... [id=rtbassoc-060171d0479a82ef0]
aws_iam_role_policy.k8s-node: Destroying... [id=k8s-node-myechuri-argo-cluster:k8s-node-myechuri-argo-cluster]
aws_instance.k8s-node: Destroying... [id=i-09f6a2a1dc6f5c4ce]
aws_iam_role_policy.k8s-node: Destruction complete after 0s
aws_route_table_association.route-table-to-subnet: Destruction complete after 0s
aws_route_table.route-table: Destroying... [id=rtb-0e374d0f30b32f29e]
aws_route_table.route-table: Destruction complete after 2s
aws_instance.k8s-node: Still destroying... [id=i-09f6a2a1dc6f5c4ce, 10s elapsed]
aws_instance.k8s-node: Still destroying... [id=i-09f6a2a1dc6f5c4ce, 20s elapsed]
aws_instance.k8s-node: Still destroying... [id=i-09f6a2a1dc6f5c4ce, 30s elapsed]
aws_instance.k8s-node: Still destroying... [id=i-09f6a2a1dc6f5c4ce, 40s elapsed]
aws_instance.k8s-node: Still destroying... [id=i-09f6a2a1dc6f5c4ce, 50s elapsed]
aws_instance.k8s-node: Destruction complete after 52s
aws_internet_gateway.gw: Destroying... [id=igw-04e635aa5a5d0cfd1]
aws_security_group.kubernetes: Destroying... [id=sg-031f663a0530b4d25]
aws_internet_gateway.gw: Provisioning with 'local-exec'...
aws_iam_instance_profile.k8s-node: Destroying... [id=k8s-node-myechuri-argo-cluster]
aws_subnet.subnet: Destroying... [id=subnet-0ed75df3e4564478d]
aws_internet_gateway.gw (local-exec): Executing: ["/bin/bash" "-c" "./cleanup-vpc.sh vpc-0f1c0e5960fe4f403 myechuri-argo-cluster"]
random_id.k8stoken-prefix: Destroying... [id=3IUc]
random_id.k8stoken-suffix: Destroying... [id=MX9JLw3fzGc]
random_id.k8stoken-suffix: Destruction complete after 0s
random_id.k8stoken-prefix: Destruction complete after 0s
aws_internet_gateway.gw (local-exec): aws-cli/2.0.30 Python/3.7.4 Darwin/18.2.0 botocore/2.0.0dev34
aws_iam_instance_profile.k8s-node: Destruction complete after 1s
aws_iam_role.k8s-node: Destroying... [id=k8s-node-myechuri-argo-cluster]
aws_internet_gateway.gw (local-exec): jq-1.6
aws_security_group.kubernetes: Destruction complete after 1s
aws_iam_role.k8s-node: Destruction complete after 1s
aws_internet_gateway.gw (local-exec): Terminating instances:
aws_internet_gateway.gw (local-exec): i-0dc322a1baa79456a
aws_internet_gateway.gw (local-exec): i-0447330b8c63825fc
aws_internet_gateway.gw: Still destroying... [id=igw-04e635aa5a5d0cfd1, 10s elapsed]
aws_subnet.subnet: Still destroying... [id=subnet-0ed75df3e4564478d, 10s elapsed]
aws_internet_gateway.gw (local-exec): Removing SGs:
aws_internet_gateway.gw (local-exec): sg-014909729531ee56a
aws_internet_gateway.gw (local-exec): sg-0599591c8bcd5ab57
aws_internet_gateway.gw (local-exec): sg-0eaf5efc060823716
aws_internet_gateway.gw: Still destroying... [id=igw-04e635aa5a5d0cfd1, 20s elapsed]
aws_subnet.subnet: Still destroying... [id=subnet-0ed75df3e4564478d, 20s elapsed]
aws_internet_gateway.gw (local-exec): Removing volumes:
aws_internet_gateway.gw (local-exec): vol-00c6def8038370c0b
aws_internet_gateway.gw (local-exec): vol-007b44d40ad1f6211
aws_internet_gateway.gw (local-exec): vol-0784f295183e2802d
aws_internet_gateway.gw (local-exec): vol-0de00f292d0da2c53
aws_internet_gateway.gw: Still destroying... [id=igw-04e635aa5a5d0cfd1, 30s elapsed]
aws_subnet.subnet: Still destroying... [id=subnet-0ed75df3e4564478d, 30s elapsed]
aws_internet_gateway.gw: Still destroying... [id=igw-04e635aa5a5d0cfd1, 40s elapsed]
aws_subnet.subnet: Still destroying... [id=subnet-0ed75df3e4564478d, 40s elapsed]
aws_internet_gateway.gw: Still destroying... [id=igw-04e635aa5a5d0cfd1, 50s elapsed]
aws_subnet.subnet: Still destroying... [id=subnet-0ed75df3e4564478d, 50s elapsed]
aws_internet_gateway.gw: Destruction complete after 56s
aws_subnet.subnet: Still destroying... [id=subnet-0ed75df3e4564478d, 1m0s elapsed]
aws_subnet.subnet: Destruction complete after 1m1s
random_shuffle.azs: Destroying... [id=-]
aws_vpc.main: Destroying... [id=vpc-0f1c0e5960fe4f403]
aws_vpc.main: Provisioning with 'local-exec'...
random_shuffle.azs: Destruction complete after 0s
aws_vpc.main (local-exec): Executing: ["/bin/bash" "-c" "./cleanup-vpc.sh vpc-0f1c0e5960fe4f403 myechuri-argo-cluster"]
aws_vpc.main (local-exec): aws-cli/2.0.30 Python/3.7.4 Darwin/18.2.0 botocore/2.0.0dev34
aws_vpc.main (local-exec): jq-1.6
aws_vpc.main (local-exec): Removing SGs:
aws_vpc.main (local-exec): sg-014909729531ee56a
aws_vpc.main (local-exec): sg-0599591c8bcd5ab57
aws_vpc.main (local-exec): sg-0eaf5efc060823716
aws_vpc.main: Still destroying... [id=vpc-0f1c0e5960fe4f403, 10s elapsed]
aws_vpc.main: Destruction complete after 15s

Destroy complete! Resources: 13 destroyed.

```

