### PR TITLE
Fix extra output from kubectl

### DIFF
--- a/scripts/init-cert/kubectl.sh
+++ b/scripts/init-cert/kubectl.sh
@@ -15,7 +15,6 @@ if [[ -d /opt/kubectl/${major_vsn}.${minor_vsn} ]]; then
     kubectl=/opt/kubectl/${major_vsn}.${minor_vsn}/kubectl
 else
     for kdir in ${kubectl_dir_base}/*; do
-        echo $kdir
         vdir=$(basename ${kdir})
         kdir_major=$(echo ${vdir} | sed -r 's/([0-9]+)\.([0-9]+)/\1/')
         if [[ ${kdir_major} -ne ${major_vsn} ]]; then


### PR DESCRIPTION
The kubectl wrapper will write some extra output if it can't find a kubectl client that matches the version from the API server, which will interfere with commands in init-cert that pipe its output into another command. I removed the line causing the extra output.

Other changes:
* Check existing certificate for both hostname and SAN IP address.
* Use functions for code where we're waiting until a timeout.
