### PR TITLE
GCE functional test, functional tests delete security groups

### DIFF
--- a/pkg/server/cloud/functional/functional_test_template.go
+++ b/pkg/server/cloud/functional/functional_test_template.go
@@ -55,6 +55,7 @@ func SetupCloudFunctionalTest(t *testing.T, c cloud.CloudClient, imageID, rootDe
 
 	img := cloud.Image{
 		ID:         imageID,
+		Name:       imageID, // GCE implementation gets these reversed
 		RootDevice: rootDevice,
 	}
 
@@ -115,6 +116,7 @@ func (ts *TestState) Cleanup(t *testing.T) {
 func SetupFirewallRules(t *testing.T, c cloud.CloudClient) error {
 	extraGroups := []string{}
 	extraCIDRs := []string{cloud.PublicCIDR}
+	fmt.Println("creating security group")
 	err := c.EnsureMilpaSecurityGroups(extraCIDRs, extraGroups)
 	return err
 }

--- a/pkg/server/cloud/gce/firewall.go
+++ b/pkg/server/cloud/gce/firewall.go
@@ -227,6 +227,14 @@ func (c *gceClient) FindSecurityGroup(sgName string) (*cloud.SecurityGroup, erro
 	return sg, nil
 }
 
+func (c *gceClient) DeleteSecurityGroup(sgName string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	fmt.Println("Deleting security group", sgName)
+	_, err := c.service.Firewalls.Delete(c.projectID, sgName).Context(ctx).Do()
+	return err
+}
+
 func portsToAllowedRules(ports []cloud.InstancePort) []*compute.FirewallAllowed {
 	allowed := make([]*compute.FirewallAllowed, len(ports))
 	for i := range ports {

--- a/pkg/server/cloud/gce/gce_functional_test.go
+++ b/pkg/server/cloud/gce/gce_functional_test.go
@@ -1,0 +1,85 @@
+package gce
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/elotl/kip/pkg/api"
+	"github.com/elotl/kip/pkg/server/cloud/functional"
+	"github.com/elotl/kip/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testControllerID = "gcefunctionaltest"
+	testProjectID    = "elotl-dev"
+	testZone         = "us-west1-b"
+	vpcID            = "default"
+	subnetName       = "default"
+	bootImageID      = "https://www.googleapis.com/compute/v1/projects/elotl-kip/global/images/elotl-kip-latest"
+	rootDevice       = ""
+	instanceType     = "f1-micro"
+)
+
+var runFunctional = flag.Bool("functional", false, "run functional system tests")
+
+func getGCEClient(t *testing.T, controllerID string) *gceClient {
+	if !util.GCEEnvVarsSet() {
+		t.Fatal("Neet to setup AWS env vars for tests")
+	}
+	clientEmail := os.Getenv("GCE_CLIENT_EMAIL")
+	privateKey := os.Getenv("GCE_PRIVATE_KEY")
+	gceClient, err := NewGCEClient(controllerID, controllerID, testProjectID,
+		WithZone(testZone), WithVPCName(vpcID), WithSubnetName(subnetName),
+		WithCredentials(clientEmail, privateKey))
+	if err != nil {
+		msg := "Error setting up GCE client: " + err.Error()
+		assert.FailNow(t, msg)
+	}
+	return gceClient
+}
+
+// Each functional test run creates a unique securty group that we need to delete
+func ensureSecurityGroupDeleted(c *gceClient) error {
+	apiGroupName := CreateKipCellNetworkTag(c.controllerID)
+	sg, err := c.FindSecurityGroup(apiGroupName)
+	if err != nil {
+		return util.WrapError(err, "Error finding security group")
+	}
+	if sg == nil {
+		fmt.Println("No security group found, not deleting group")
+		return nil
+	}
+	err = c.DeleteSecurityGroup(apiGroupName)
+	return err
+}
+
+func TestGCECloud(t *testing.T) {
+	if !(*runFunctional) {
+		t.Skip("skipping gce cloud functional tests")
+	}
+	fmt.Printf("Running GCE Functional Tests\n")
+	if !util.GCEEnvVarsSet() {
+		t.Fatal("Neet to setup GCE env vars for tests")
+	}
+
+	controllerID := api.SimpleNameGenerator.GenerateName(testControllerID)
+	fmt.Println("GCE Controller ID:", controllerID)
+	gceClient := getGCEClient(t, controllerID)
+
+	defer func() {
+		err := ensureSecurityGroupDeleted(gceClient)
+		if err != nil {
+			assert.FailNow(t, "Failed to delete cell security group")
+		}
+	}()
+
+	ts, err := functional.SetupCloudFunctionalTest(
+		t, gceClient, bootImageID, rootDevice, instanceType)
+	if err != nil {
+		assert.FailNow(t, "Failed to setup functional test: %s", err.Error())
+	}
+	defer ts.Cleanup(t)
+}

--- a/pkg/server/cloud/gce/instances.go
+++ b/pkg/server/cloud/gce/instances.go
@@ -532,6 +532,7 @@ func (c *gceClient) GetImage(spec cloud.BootImageSpec) (cloud.Image, error) {
 			creationTime = &ts
 		}
 	}
+	// TODO: these values seem to be reversed?
 	return cloud.Image{
 		ID:           resp.Name,
 		Name:         resp.SelfLink,

--- a/pkg/util/test_helpers.go
+++ b/pkg/util/test_helpers.go
@@ -51,3 +51,11 @@ func AzureEnvVarsSet() bool {
 	}
 	return true
 }
+
+func GCEEnvVarsSet() bool {
+	if os.Getenv("GCE_CLIENT_EMAIL") == "" ||
+		os.Getenv("GCE_PRIVATE_KEY") == "" {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
This needs additional changes in order to be incorporated in the build:

* Added to scripts/run_tests.sh
* Update the serviceAccount and roles used by travis-ci.com.  Allow both pushing to GCR and a select set of functionality to run GCE funcational tests.