### PR TITLE
Make sure TF configs can be used as modules

### DIFF
--- a/deploy/manifests/kip/overlays/minikube/README.md
+++ b/deploy/manifests/kip/overlays/minikube/README.md
@@ -1,9 +1,0 @@
-## Deploy to an existing Minikube
-
-1. Set `region`, `accessKeyID`, `secretAccessKey`, `vpcID`, `subnetID` and `extraSecurityGroups`:
-
-     $ vi provider.yaml
-
-2.  Apply via: 
-
-     $ kustomize build . | kubectl apply -f -

--- a/deploy/manifests/kip/overlays/minikube/kustomization.yaml
+++ b/deploy/manifests/kip/overlays/minikube/kustomization.yaml
@@ -1,5 +1,32 @@
+# Steps to deploy via Minikube:
+# 1. Create your overlay:
+#     $ mkdir -p overlays/local-minikube
+#     $ cat <<EOF > overlays/local-minikube/kustomization.yaml
+#     bases:
+#     - ../minikube
+#     namespace: kube-system
+#     configMapGenerator:
+#     - name: kip-config
+#       behavior: merge
+#       files:
+#       - provider.yaml
+#     secretGenerator:
+#     - name: kip-secrets
+#       literals:
+#       - AWS_ACCESS_KEY_ID=...
+#       - AWS_SECRET_ACCESS_KEY=...
+#     EOF
+#     $ cp overlays/minikube/provider.yaml overlays/local-minikube/
+# 2. Set VPC, subnet ID and security group:
+#     $ vi overlays/local-minikube/provider.yaml
+# 3. Set your AWS access keys:
+#     $ vi overlays/local-minikube/kustomization.yaml
+# 4. Apply via:
+#     $ kustomize build overlays/local-minikube | kubectl apply -f -
 bases:
 - ../../base
+patchesStrategicMerge:
+- statefulset.yaml
 configMapGenerator:
 - name: config
   behavior: merge

--- a/deploy/manifests/kip/overlays/minikube/kustomization.yaml
+++ b/deploy/manifests/kip/overlays/minikube/kustomization.yaml
@@ -11,7 +11,7 @@
 #       files:
 #       - provider.yaml
 #     secretGenerator:
-#     - name: kip-secrets
+#     - name: provider-secret
 #       literals:
 #       - AWS_ACCESS_KEY_ID=...
 #       - AWS_SECRET_ACCESS_KEY=...

--- a/deploy/manifests/kip/overlays/minikube/statefulset.yaml
+++ b/deploy/manifests/kip/overlays/minikube/statefulset.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: provider
+spec:
+  template:
+    spec:
+      containers:
+      - name: kip
+        envFrom:
+        - secretRef:
+            name: provider-secret

--- a/deploy/terraform-aws/cleanup-vpc.sh
+++ b/deploy/terraform-aws/cleanup-vpc.sh
@@ -5,7 +5,7 @@
 
 function usage() {
     {
-        echo "Usage $0 <vpc-id> <cluster-name>"
+        echo "Usage $0 <vpc-id> <cluster_name>"
         echo "You can also set the environment variables"
         echo "VPC_ID and CLUSTER_NAME."
     } >&2

--- a/deploy/terraform-aws/env.tfvars.example
+++ b/deploy/terraform-aws/env.tfvars.example
@@ -2,35 +2,35 @@
 # EC2 instances for SSH access. See
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html on how
 # to create or import one to EC2. If not specified, a new key will be created.
-#ssh-key-name = ""
+#ssh_key_name = ""
 
 # The name of the cluster.
-#cluster-name = ""
+#cluster_name = ""
 
 # AWS region to use. Currently only us-east-1 is supported
 #region = ""
 
 # VPC CIDR.
-#vpc-cidr = ""
+#vpc_cidr = ""
 
 # Kubernetes pod CIDR. Note: since on AWS the VPC CNI plugin is used, pods will
 # get an IP address from the VPC CIDR, not from the pod CIDR.
-#pod-cidr = ""
+#pod_cidr = ""
 
 # Kubernetes service CIDR. Cluster IPs will be allocated from this CIDR.
-#service-cidr = ""
+#service_cidr = ""
 
 # If left empty, the latest available version will be used.
-#k8s-version = ""
+#k8s_version = ""
 
 #  Size of the root device volume in GB on the node. E.g. "20"
-#node-disk-size = ""
+#node_disk_size = ""
 
 # Exclude certain AZs to prevent capacity problems. E.g. ["use1-az3"]
-#excluded-azs = ""
+#excluded_azs = ""
 
 # If not set, Ubuntu 16.04 will be used.
-#node-ami = ""
+#node_ami = ""
 
 # The path for a kip kustomize directory.
-#kustomize-dir = ""
+#kustomize_dir = ""

--- a/deploy/terraform-aws/main.tf
+++ b/deploy/terraform-aws/main.tf
@@ -46,7 +46,7 @@ resource "aws_vpc" "main" {
 
   provisioner "local-exec" {
     when        = destroy
-    command     = "./cleanup-vpc.sh ${self.id} ${var.cluster_name}"
+    command     = "${path.module}/cleanup-vpc.sh ${self.id} ${var.cluster_name}"
     interpreter = ["/bin/bash", "-c"]
     environment = {
       "AWS_REGION"         = var.region
@@ -62,7 +62,7 @@ resource "aws_internet_gateway" "gw" {
 
   provisioner "local-exec" {
     when        = destroy
-    command     = "./cleanup-vpc.sh ${self.vpc_id} ${var.cluster_name}"
+    command     = "${path.module}/cleanup-vpc.sh ${self.vpc_id} ${var.cluster_name}"
     interpreter = ["/bin/bash", "-c"]
     environment = {
       "AWS_REGION"         = var.region
@@ -319,7 +319,7 @@ data "external" "manifest" {
 }
 
 data "template_file" "node-userdata" {
-  template = file("node.sh")
+  template = file("${path.module}/node.sh")
 
   vars = {
     k8stoken                  = local.k8stoken

--- a/deploy/terraform-aws/main.tf
+++ b/deploy/terraform-aws/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = "~> 0.12.0"
 }
 
 provider "external" {

--- a/deploy/terraform-aws/outputs.tf
+++ b/deploy/terraform-aws/outputs.tf
@@ -1,7 +1,7 @@
-output "node-ip" {
+output "node_ip" {
   value = aws_instance.k8s_node.public_ip
 }
 
-output "efs-ip" {
+output "efs_ip" {
   value = aws_efs_mount_target.efs.*.ip_address
 }

--- a/deploy/terraform-aws/outputs.tf
+++ b/deploy/terraform-aws/outputs.tf
@@ -1,5 +1,5 @@
 output "node-ip" {
-  value = aws_instance.k8s-node.public_ip
+  value = aws_instance.k8s_node.public_ip
 }
 
 output "efs-ip" {

--- a/deploy/terraform-aws/outputs.tf
+++ b/deploy/terraform-aws/outputs.tf
@@ -1,7 +1,15 @@
 output "node_ip" {
-  value = aws_instance.k8s_node.public_ip
+  value       = aws_instance.k8s_node.public_ip
+  description = "Node IP address"
 }
 
 output "efs_ip" {
-  value = aws_efs_mount_target.efs.*.ip_address
+  value       = aws_efs_mount_target.efs.*.ip_address
+  description = "EFS IP address"
+}
+
+output "ssh_key" {
+  value       = length(tls_private_key.ssh_key) > 0 ? tls_private_key.ssh_key[0].private_key_pem : ""
+  description = "SSH key"
+  sensitive   = true
 }

--- a/deploy/terraform-aws/variables.tf
+++ b/deploy/terraform-aws/variables.tf
@@ -40,7 +40,7 @@ variable "node_ami" {
 }
 
 variable "kustomize_dir" {
-  default = "../manifests/kip/base"
+  default = "github.com/elotl/kip/deploy/manifests/kip/base?ref=v1.0.0"
 }
 
 variable "efs_enable" {

--- a/deploy/terraform-aws/variables.tf
+++ b/deploy/terraform-aws/variables.tf
@@ -1,8 +1,8 @@
-variable "ssh-key-name" {
+variable "ssh_key_name" {
   default = ""
 }
 
-variable "cluster-name" {
+variable "cluster_name" {
   default = "vk"
 }
 
@@ -10,59 +10,59 @@ variable "region" {
   default = "us-east-1"
 }
 
-variable "vpc-cidr" {
+variable "vpc_cidr" {
   default = "10.0.0.0/16"
 }
 
-variable "pod-cidr" {
+variable "pod_cidr" {
   default = "172.20.0.0/16"
 }
 
-variable "service-cidr" {
+variable "service_cidr" {
   default = "10.96.0.0/12"
 }
 
-variable "k8s-version" {
+variable "k8s_version" {
   default = ""
 }
 
-variable "node-disk-size" {
+variable "node_disk_size" {
   default = 15
 }
 
-variable "excluded-azs" {
+variable "excluded_azs" {
   type    = list(string)
   default = ["use1-az3"]
 }
 
-variable "node-ami" {
+variable "node_ami" {
   default = ""
 }
 
-variable "kustomize-dir" {
+variable "kustomize_dir" {
   default = "../manifests/kip/base"
 }
 
-variable "efs-enable" {
+variable "efs_enable" {
   type    = bool
   default = false
   description = "Create an EFS volume cells and/or pods in the VPC can mount and use."
 }
 
-variable "efs-performance-mode" {
+variable "efs_performance_mode" {
   type        = string
   default     = "generalPurpose"
   description = "Optional. The file system performance mode. Can be either generalPurpose or maxIO."
 }
 
-variable "efs-provisioned-throughput-in-mibps" {
+variable "efs_provisioned_throughput_in_mibps" {
   type        = number
   default     = 0
-  description = "Optional. The throughput, measured in MiB/s, that you want to provision for the file system. Only applicable with efs-throughput-mode set to provisioned."
+  description = "Optional. The throughput, measured in MiB/s, that you want to provision for the file system. Only applicable with efs_throughput_mode set to provisioned."
 }
 
-variable "efs-throughput-mode" {
+variable "efs_throughput_mode" {
   type        = string
   default     = "bursting"
-  description = "Optional. Throughput mode for the file system. Defaults to bursting. Valid values: bursting, provisioned. When using provisioned, also set efs-provisioned-throughput-in-mibps."
+  description = "Optional. Throughput mode for the file system. Defaults to bursting. Valid values: bursting, provisioned. When using provisioned, also set efs_provisioned_throughput_in_mibps."
 }

--- a/deploy/terraform-gcp/env.tfvars.example
+++ b/deploy/terraform-gcp/env.tfvars.example
@@ -6,11 +6,11 @@
 #project = ""
 
 # Cluster name.
-#cluster-name = ""
+#cluster_name = ""
 
 # Region and zone to create resources in.
 #region = ""
 #zone = ""
 
 # The path for a kip kustomize directory.
-#kustomize-dir = ""
+#kustomize_dir = ""

--- a/deploy/terraform-gcp/main.tf
+++ b/deploy/terraform-gcp/main.tf
@@ -60,7 +60,7 @@ resource "google_container_cluster" "cluster" {
   }
 }
 
-resource "google_container_node_pool" "node-pool" {
+resource "google_container_node_pool" "node_pool" {
   name       = "node-pool-${var.cluster_name}"
   location   = var.zone
   cluster    = google_container_cluster.cluster.name

--- a/deploy/terraform-gcp/main.tf
+++ b/deploy/terraform-gcp/main.tf
@@ -26,7 +26,7 @@ locals {
 }
 
 resource "google_container_cluster" "cluster" {
-  name = var.cluster-name
+  name = var.cluster_name
 
   # Create a zonal cluster. In production, you want a regional cluster with
   # multiple masters spread across zones in the region.
@@ -48,8 +48,8 @@ resource "google_container_cluster" "cluster" {
   }
 
   ip_allocation_policy {
-    cluster_ipv4_cidr_block   = var.pod-cidr
-    services_ipv4_cidr_block  = var.service-cidr
+    cluster_ipv4_cidr_block   = var.pod_cidr
+    services_ipv4_cidr_block  = var.service_cidr
   }
 
   master_authorized_networks_config {
@@ -61,7 +61,7 @@ resource "google_container_cluster" "cluster" {
 }
 
 resource "google_container_node_pool" "node-pool" {
-  name       = "node-pool-${var.cluster-name}"
+  name       = "node-pool-${var.cluster_name}"
   location   = var.zone
   cluster    = google_container_cluster.cluster.name
   node_count = 1
@@ -83,21 +83,21 @@ resource "google_container_node_pool" "node-pool" {
 }
 
 resource "google_filestore_instance" "filestore" {
-  count = var.filestore-enable ? 1 : 0
+  count = var.filestore_enable ? 1 : 0
 
-  name = var.cluster-name
+  name = var.cluster_name
   zone = var.zone
-  tier = var.filestore-tier
+  tier = var.filestore_tier
 
   file_shares {
-    name        = var.filestore-fileshare-name
-    capacity_gb = var.filestore-fileshare-capacity-gb
+    name        = var.filestore_fileshare_name
+    capacity_gb = var.filestore_fileshare_capacity_gb
   }
 
   networks {
     network = "default"
     modes   = ["MODE_IPV4"]
-    reserved_ip_range = var.filestore-reserved-ip-range
+    reserved_ip_range = var.filestore_reserved_ip_range
   }
 }
 
@@ -168,7 +168,7 @@ resource "null_resource" "client_permissions" {
 }
 
 resource "null_resource" "deploy" {
-  count = length(var.kustomize-dir) > 0 ? 1 : 0
+  count = length(var.kustomize_dir) > 0 ? 1 : 0
 
   provisioner "local-exec" {
     environment = {
@@ -180,7 +180,7 @@ resource "null_resource" "deploy" {
       "-c",
     ]
     # This needs kubectl and kustomize.
-    command = "kustomize build ${var.kustomize-dir} | kubectl apply -f -"
+    command = "kustomize build ${var.kustomize_dir} | kubectl apply -f -"
   }
 
   triggers = {

--- a/deploy/terraform-gcp/main.tf
+++ b/deploy/terraform-gcp/main.tf
@@ -154,7 +154,7 @@ resource "null_resource" "client_permissions" {
     environment = {
       KUBECONFIG = "${path.module}/kubeconfig"
     }
-    command = "kubectl apply -f cluster-admin.yaml --username=client --password=${local.password}"
+    command = "kubectl apply -f ${path.module}/cluster-admin.yaml --username=client --password=${local.password}"
   }
 
   triggers = {

--- a/deploy/terraform-gcp/variables.tf
+++ b/deploy/terraform-gcp/variables.tf
@@ -29,7 +29,7 @@ variable "service_cidr" {
 }
 
 variable "kustomize_dir" {
-  default     = "../manifests/kip/overlays/gcp"
+  default     = "github.com/elotl/kip/deploy/manifests/kip/overlays/gcp?ref=v1.0.0"
   description = "A kustomization directory that will be applied once the cluster is created. Leave it empty to disable."
 }
 

--- a/deploy/terraform-gcp/variables.tf
+++ b/deploy/terraform-gcp/variables.tf
@@ -1,4 +1,4 @@
-variable "cluster-name" {
+variable "cluster_name" {
   default     = "vk"
   description = "A name for the cluster and its associated resources."
 }
@@ -18,46 +18,46 @@ variable "zone" {
   description = "The zone inside the region to create resources in."
 }
 
-variable "pod-cidr" {
+variable "pod_cidr" {
   default     = ""
   description = "The CIDR in the cluster used for pod IP addresses. By default, a CIDR will be allocated automatically."
 }
 
-variable "service-cidr" {
+variable "service_cidr" {
   default     = ""
   description = "The CIDR in the cluster used for service IP addresses. By default, a CIDR will be allocated automatically."
 }
 
-variable "kustomize-dir" {
+variable "kustomize_dir" {
   default     = "../manifests/kip/overlays/gcp"
   description = "A kustomization directory that will be applied once the cluster is created. Leave it empty to disable."
 }
 
-variable "filestore-enable" {
+variable "filestore_enable" {
   type        = bool
   default     = false
   description = "Enable to create a filestore storage for this cluster. The filestore will contain one fileshare."
 }
 
-variable "filestore-tier" {
+variable "filestore_tier" {
   type        = string
   default     = "STANDARD"
   description = "The service tier of the instance. Possible values are: TIER_UNSPECIFIED, STANDARD, PREMIUM."
 }
 
-variable "filestore-fileshare-capacity-gb" {
+variable "filestore_fileshare_capacity_gb" {
   type        = number
   default     = 1024
   description = "File share capacity in GiB. This must be at least 1024 GiB for the standard tier, or 2560 GiB for the premium tier."
 }
 
-variable "filestore-fileshare-name" {
+variable "filestore_fileshare_name" {
   type        = string
   default     = "data"
   description = "The name of the file share to be created. It must be 16 characters or less."
 }
 
-variable "filestore-reserved-ip-range" {
+variable "filestore_reserved_ip_range" {
   type        = string
   default     = "10.20.0.0/29"
   description = "A /29 CIDR block that identifies the range of IP addresses reserved for this filestore."

--- a/deploy/terraform-vpn/kustomization/kustomization.yaml.tmpl
+++ b/deploy/terraform-vpn/kustomization/kustomization.yaml.tmpl
@@ -1,5 +1,5 @@
 bases:
-- ../../manifests/kip/overlays/minikube/
+- github.com/elotl/kip/deploy/manifests/kip/overlays/minikube?ref=v1.0.0
 namespace: kube-system
 resources:
 - vpn-deployment.yaml

--- a/deploy/terraform-vpn/main.tf
+++ b/deploy/terraform-vpn/main.tf
@@ -78,7 +78,7 @@ module "vpc" {
   }
 }
 
-resource "local_file" "vpn-deployment-yaml" {
+resource "local_file" "vpn_deployment_yaml" {
   content         = templatefile("${path.module}/kustomization/vpn-deployment.yaml.tmpl", {
     dnspolicy=var.vpn_hostnetwork ? "ClusterFirstWithHostNet" : "ClusterFirst",
     hostnetwork=var.vpn_hostnetwork ? "true" : "false",
@@ -88,7 +88,7 @@ resource "local_file" "vpn-deployment-yaml" {
   file_permission = "0644"
 }
 
-resource "local_file" "kustomization-yaml" {
+resource "local_file" "kustomization_yaml" {
   sensitive_content = templatefile("${path.module}/kustomization/kustomization.yaml.tmpl", {
     aws_access_key_id=var.aws_access_key_id,
     aws_secret_access_key=var.aws_secret_access_key,
@@ -97,7 +97,7 @@ resource "local_file" "kustomization-yaml" {
   file_permission   = "0600"
 }
 
-resource "local_file" "aws-vpn-client-env" {
+resource "local_file" "aws_vpn_client_env" {
   sensitive_content = templatefile("${path.module}/kustomization/aws-vpn-client.env.tmpl", {
     tunnel1_address=module.vpn_gateway.vpn_connection_tunnel1_address,
     tunnel1_cgw_inside_address=module.vpn_gateway.vpn_connection_tunnel1_cgw_inside_address,
@@ -118,7 +118,7 @@ resource "local_file" "aws-vpn-client-env" {
   file_permission   = "0600"
 }
 
-resource "local_file" "provider-yaml" {
+resource "local_file" "provider_yaml" {
   sensitive_content = templatefile("${path.module}/kustomization/provider.yaml.tmpl", {
     name=var.name,
     region=var.region,
@@ -130,7 +130,7 @@ resource "local_file" "provider-yaml" {
   file_permission   = "0600"
 }
 
-resource "local_file" "command-extra-args-yaml" {
+resource "local_file" "command_extra_args_yaml" {
   content = templatefile("${path.module}/kustomization/command-extra-args.yaml.tmpl", {
     local_dns=var.local_dns,
   })
@@ -138,7 +138,7 @@ resource "local_file" "command-extra-args-yaml" {
   file_permission   = "0644"
 }
 
-resource "local_file" "node-local-dns-yaml" {
+resource "local_file" "node_local_dns_yaml" {
   content = templatefile("${path.module}/kustomization/node-local-dns.yaml.tmpl", {
     cluster_domain=var.cluster_domain,
     local_dns=var.local_dns,
@@ -162,20 +162,20 @@ resource "null_resource" "deploy" {
   }
 
   triggers = {
-    vpn-deployment-yaml=local_file.vpn-deployment-yaml.content,
-    node-local-dns-yaml=local_file.node-local-dns-yaml.content
-    aws-vpn-client-env=local_file.aws-vpn-client-env.sensitive_content,
-    kustomization-yaml=local_file.kustomization-yaml.sensitive_content,
-    command-extra-args-yaml=local_file.command-extra-args-yaml.content,
-    provider-yaml=local_file.provider-yaml.sensitive_content,
+    vpn_deployment_yaml=local_file.vpn_deployment_yaml.content,
+    node_local_dns_yaml=local_file.node_local_dns_yaml.content
+    aws_vpn_client_env=local_file.aws_vpn_client_env.sensitive_content,
+    kustomization_yaml=local_file.kustomization_yaml.sensitive_content,
+    command_extra_args_yaml=local_file.command_extra_args_yaml.content,
+    provider_yaml=local_file.provider_yaml.sensitive_content,
   }
 
   depends_on = [
-    local_file.vpn-deployment-yaml,
-    local_file.node-local-dns-yaml,
-    local_file.aws-vpn-client-env,
-    local_file.kustomization-yaml,
-    local_file.command-extra-args-yaml,
-    local_file.provider-yaml,
+    local_file.vpn_deployment_yaml,
+    local_file.node_local_dns_yaml,
+    local_file.aws_vpn_client_env,
+    local_file.kustomization_yaml,
+    local_file.command_extra_args_yaml,
+    local_file.provider_yaml,
   ]
 }

--- a/scripts/run_smoke_test.sh
+++ b/scripts/run_smoke_test.sh
@@ -31,7 +31,7 @@ cleanup() {
         kill -9 $PORTFW_PID
     fi
     cd $ROOT_DIR/deploy/terraform-aws
-    terraform destroy -var cluster-name=${CLUSTER_NAME} -auto-approve
+    terraform destroy -var cluster_name=${CLUSTER_NAME} -auto-approve
 }
 
 update_vk() {
@@ -66,9 +66,9 @@ trap cleanup EXIT
 # Create a test cluster.
 cd $ROOT_DIR/deploy/terraform-aws
 terraform init
-terraform apply -var cluster-name=${CLUSTER_NAME} -auto-approve
-terraform show -json | jq -r '.values.root_module.resources | .[] | select(.address=="tls_private_key.ssh-key") | .values.private_key_pem' > $SSH_KEY_FILE
-SSH_HOST=$(terraform show -json | jq -r '.values.root_module.resources | .[] | select(.address=="aws_instance.k8s-node") | .values.public_ip')
+terraform apply -var cluster_name=${CLUSTER_NAME} -auto-approve
+terraform show -json | jq -r '.values.root_module.resources | .[] | select(.address=="tls_private_key.ssh_key") | .values.private_key_pem' > $SSH_KEY_FILE
+SSH_HOST=$(terraform show -json | jq -r '.values.root_module.resources | .[] | select(.address=="aws_instance.k8s_node") | .values.public_ip')
 
 fetch_kubeconfig
 

--- a/scripts/run_smoke_test.sh
+++ b/scripts/run_smoke_test.sh
@@ -1,37 +1,88 @@
-#!/bin/bash
-
-set -e
+#!/usr/bin/env bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$SCRIPT_DIR/..
-cd $ROOT_DIR
-
-SSH_KEY_FILE=$(mktemp)
-chmod 0600 $SSH_KEY_FILE
-
-PORTFW_PID=""
 
 BUILD=${TRAVIS_BUILD_NUMBER:-local}
 CLUSTER_NAME="build-$BUILD"
+USE_REGION=${USE_REGION:-us-east-1}
+STATE_BUCKET=${STATE_BUCKET:-elotl-tf-state}
+STATE_PATH=${STATE_PATH:-build/terraform-${BUILD}.tfstate}
 
-export KUBECONFIG=$(mktemp)
+setup() {
+    SSH_KEY_FILE=$(mktemp)
+    chmod 0600 $SSH_KEY_FILE
+    export KUBECONFIG=$(mktemp)
+    TFDIR=$(mktemp -d)
+    PORTFW_PID=""
+}
+
+handle_error() {
+    trap - EXIT
+    show_kube_info || true
+    cleanup || true
+}
 
 cleanup() {
-    kubectl get pods -A || true
-    kubectl get nodes || true
-    kubectl -n kube-system describe pod -l app=kip-provider || true
-    kubectl logs -n kube-system -l app=kip-provider -c init-cert --tail=-1 || true
-    kubectl logs -n kube-system -l app=kip-provider -c kip --tail=-1 || true
-    kubectl delete pod nginx > /dev/null 2>&1 || true
-    kubectl delete svc nginx > /dev/null 2>&1 || true
-    kubectl delete pod test > /dev/null 2>&1 || true
-    rm -rf $SSH_KEY_FILE
-    rm -rf $KUBECONFIG
-    if [[ -n "$PORTFW_PID" ]]; then
-        kill -9 $PORTFW_PID
-    fi
-    cd $ROOT_DIR/deploy/terraform-aws
-    terraform destroy -var cluster_name=${CLUSTER_NAME} -auto-approve
+    delete_kube_resources
+    destroy_cluster
+    delete_temp_files
+    stop_port_forwarding
+}
+
+stop_port_forwarding() {
+    [[ -n "$PORTFW_PID" ]] && kill -9 $PORTFW_PID || true
+}
+
+delete_temp_files() {
+    [[ -n "$SSH_KEY_FILE" ]] && rm -rf $SSH_KEY_FILE
+    [[ -n "$KUBECONFIG" ]] && rm -rf $KUBECONFIG
+    [[ -n "$TFDIR" ]] && rm -rf $TFDIR
+}
+
+delete_kube_resources() {
+    kubectl delete pod nginx
+    kubectl delete svc nginx
+    kubectl delete pod test
+}
+
+show_kube_info() {
+    kubectl get pods -A
+    kubectl get nodes
+    kubectl -n kube-system describe pod -l app=kip-provider
+    kubectl logs -n kube-system -l app=kip-provider -c init-cert --tail=-1
+    kubectl logs -n kube-system -l app=kip-provider -c kip --tail=-1
+}
+
+create_cluster() {
+    # Create a test cluster.
+    pushd $TFDIR
+    cat > main.tf <<EOF
+terraform {
+  required_version = "~> 0.12"
+  backend "s3" {
+    region  = "${USE_REGION}"
+    bucket  = "${STATE_BUCKET}"
+    key     = "${STATE_PATH}"
+    encrypt = "true"
+  }
+}
+module "kip-aws" {
+  source        = "${ROOT_DIR}/deploy/terraform-aws"
+  cluster_name  = "${CLUSTER_NAME}"
+}
+EOF
+    terraform init
+    terraform apply -auto-approve
+    terraform show -json | jq -r '.values.root_module.child_modules[] | select(.address=="module.kip-aws") | .resources[] | select(.address=="tls_private_key.ssh_key") | .values.private_key_pem' > $SSH_KEY_FILE
+    SSH_HOST=$(terraform show -json | jq -r '.values.root_module.child_modules[] | select(.address=="module.kip-aws") | .resources[] | select(.address=="aws_instance.k8s_node") | .values.public_ip')
+    popd
+}
+
+destroy_cluster() {
+    pushd $TFDIR
+    terraform destroy -auto-approve
+    popd
 }
 
 update_vk() {
@@ -61,17 +112,17 @@ fetch_kubeconfig() {
     timeout 60s sh -c "while true; do kubectl get sa default > /dev/null 2>&1 && exit 0; done"
 }
 
-trap cleanup EXIT
+test_once() {
+    set -euxo pipefail
+    trap handle_error EXIT
+    setup
+    create_cluster
+    fetch_kubeconfig
+    update_vk
+    run_smoke_test
+    cleanup
+    trap - EXIT
+}
 
-# Create a test cluster.
-cd $ROOT_DIR/deploy/terraform-aws
-terraform init
-terraform apply -var cluster_name=${CLUSTER_NAME} -auto-approve
-terraform show -json | jq -r '.values.root_module.resources | .[] | select(.address=="tls_private_key.ssh_key") | .values.private_key_pem' > $SSH_KEY_FILE
-SSH_HOST=$(terraform show -json | jq -r '.values.root_module.resources | .[] | select(.address=="aws_instance.k8s_node") | .values.public_ip')
-
-fetch_kubeconfig
-
-update_vk
-
-run_smoke_test
+# Run test_once() if running as a shell script, and return if sourced.
+(return 0 2>/dev/null) || test_once


### PR DESCRIPTION
It's never been a goal to reuse the Terraform examples, since they are pretty simplistic and intentionally ignore details that are important for a production grade setup. That being said, they are good for creating a new environment, quickly and without much hassle; so I refactored them here to ensure they can be used as modules, so the code can be used externally, via modules. The end goal is to be able to simply create a new AWS or GCP environment that we know works with Kip (I'd like to use it to set up an image test pipeline).

While testing the configs, I also bumped into an issue caused by 8ae8d723e544e3ee82a8b4d2ef6f22aca0c0ec1e, which broke terraform-vpn, so I also added a fix for that.