### PR TITLE
Fix memory calculation for custom instance types

### DIFF
--- a/pkg/util/instanceselector/instanceselector.go
+++ b/pkg/util/instanceselector/instanceselector.go
@@ -253,6 +253,8 @@ func cheapestCustomInstanceSizeForCPUAndMemory(cid CustomInstanceData, memoryReq
 			if memory < cid.MinimumMemoryPerCPU*cpu {
 				memory = cid.MinimumMemoryPerCPU * cpu
 			}
+			ceil := math.Ceil(float64(memory / cid.BaseMemoryUnit))
+			memory = float32(ceil) * cid.BaseMemoryUnit
 			price := memory*cid.PricePerGBOfMemory + cpu*cid.PricePerCPU
 			if price < customPrice {
 				customPrice = price

--- a/pkg/util/instanceselector/instanceselector_test.go
+++ b/pkg/util/instanceselector/instanceselector_test.go
@@ -407,6 +407,11 @@ func TestGCEResourcesToInstanceType(t *testing.T) {
 			instanceType: "e2-micro",
 			sustainedCPU: false,
 		},
+		{
+			Resources:    api.ResourceSpec{Memory: "0.5Gi", CPU: "1.0"},
+			instanceType: "n1-custom-1-1024",
+			sustainedCPU: false,
+		},
 	}
 	runInstanceTypeTests(t, testCases)
 }


### PR DESCRIPTION
When creating an instance on GCP with `api.ResourceSpec{Memory: "0.5Gi", CPU: "1.0"}`, we get a custom type with 0.9GB memory: `instanceType: "n1-custom-1-921"`.

That comes from the script generating instance data: https://github.com/elotl/kip/blob/master/scripts/create_instance_data/create_gce_instance_data.py#L33

https://cloud.google.com/compute/docs/instances/creating-instance-with-custom-machine-type#n1_custom_machine_types says:

> For N1 machine types, select between 0.9 GB and 6.5 GB per vCPU, inclusive.

but apparently an additional requirement is that it _still_ needs to be a multiple of 0.25GB.

I added another check for the amount of memory when generating instance sizes, ensuring that it is a multiple of the base memory unit (0.25GB).

This fixes #171