### PR TITLE
Ensure multiple ECR images can be pulled for a pod

### DIFF
--- a/pkg/server/pod_controller.go
+++ b/pkg/server/pod_controller.go
@@ -368,6 +368,15 @@ func (c *PodController) loadRegistryCredentials(pod *api.Pod) (map[string]api.Re
 
 	// AWS is different, they require us to authenticate with IAM
 	// Do that auth and pass along the username and password
+	var err error
+	allCreds, err = c.updateCredsWithRegistryAuth(pod, allCreds)
+	if err != nil {
+		return nil, err
+	}
+	return allCreds, nil
+}
+
+func (c *PodController) updateCredsWithRegistryAuth(pod *api.Pod, allCreds map[string]api.RegistryCredentials) (map[string]api.RegistryCredentials, error) {
 	if err := api.ForAllUnitsWithError(pod, func(unit *api.Unit) error {
 		image := unit.Image
 		server, _, err := util.ParseImageSpec(image)
@@ -394,7 +403,7 @@ func (c *PodController) loadRegistryCredentials(pod *api.Pod) (map[string]api.Re
 		}
 		return nil
 	}); err != nil {
-		return nil, err
+		return allCreds, err
 	}
 	return allCreds, nil
 }


### PR DESCRIPTION
When iterating through images in the podspec, we need to make sure that:

1. We don't stop once the first ECR image is hit. In the podspec, there
   might be multiple images in different regions that need ECR
   credentials.
2. We take into account both regular containers and init containers.