### PR TITLE
Change AWS terraform configuration to work with Terraform 0.13+

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,31 +20,13 @@ When workloads run on Kip, your cluster size naturally scales with the cluster w
 
 There are two ways to get Kip up and running.
 
-* Option 1: Use the provided terraform scripts to create a new Kubernetes cluster with a single Kip node on AWS or GKE.
-* Option 2: Add Kip to an existing kubernetes cluster.
+1. Use the provided Terraform scripts to create a new Kubernetes cluster
+   with a single Kip node. There are instructions for
+   [AWS](deploy/terraform-aws/README.md) and
+   [GCP](deploy/terraform-gcp/README.md).
+2. Add Kip to an existing kubernetes cluster. This option is documented below.
 
-### Installation Option 1: Create a Minimal K8s Cluster
-
-Prequisites:
-- An AWS or Google Cloud account
-- [Terraform](https://www.terraform.io/downloads.html) >= 0.12
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) >= 1.14
-- [kustomize](https://github.com/kubernetes-sigs/kustomize) >= 3.0.0
-- [jq](https://github.com/stedolan/jq) and [aws-cli](https://aws.amazon.com/cli/) if using AWS
-
-In [deploy/terraform-aws](deploy/terraform-aws), you will find a terraform config that creates a simple one master, one worker cluster and starts Kip on AWS.
-
-``` bash
-cd deploy/terraform-aws
-terraform init
-cp env.tfvars.example myenv.tfvars
-vi myenv.tfvars  # customize variables as necessary
-terraform apply -var-file myenv.tfvars
-```
-
-On Google Cloud, the config under `deploy/terraform-gcp` works in a similar way, but uses a GKE base cluster.
-
-### Installation Option 2: Using an Existing Cluster
+### Install Kip using an existing cluster
 
 To deploy Kip into an existing cluster, you'll need to setup cloud credentials that allow the Kip provider to manipulate cloud instances, networking and other cloud resources.
 

--- a/deploy/terraform-aws/README.md
+++ b/deploy/terraform-aws/README.md
@@ -22,10 +22,10 @@ Initialize Terraform and verify the configuration:
 
 [Upload][0] your SSH public key to AWS, and remember its name. Make
 sure the private key for this public key is your default SSH key:
-`$HOME/.ssh/id_rsa` (NB: investigate the SSH key situation to see if
-there’s an easier way to get this set-up correctly.) In this example
-we’ll name our key-pair “alice-key”. Come up with a unique cluster
-name like “alice-cluster”. Finally put these values into a tfvars file:
+`$HOME/.ssh/id_rsa`. Alternatively you can use an SSH key pair generated from
+AWS. In this example we’ll name our key-pair “alice-key”. Come up with
+a unique cluster name like “alice-cluster”. Finally put these values
+into a tfvars file:
 
 [0]: https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#KeyPairs:
 

--- a/deploy/terraform-aws/README.md
+++ b/deploy/terraform-aws/README.md
@@ -7,15 +7,36 @@ The Terraform config here can be used to provision a simple test cluster with ki
 ## Getting Started
 
 You need:
+
 * an AWS account configured (check that e.g. `aws iam get-user` works)
 * Terraform >= 0.12
 * aws-cli
 * jq
 
-You can then apply your config:
+Initialize Terraform and verify the configuration:
 
-    cp env.tfvars.example myenv.tfvars
-    vi myenv.tfvars # You can change settings for your cluster here.
+    $ terraform init
+    [... lots of output ...]
+    $ terraform plan
+    [... lots of output ...]
+
+[Upload][0] your SSH public key to AWS, and remember its name. Make
+sure the private key for this public key is your default SSH key:
+`$HOME/.ssh/id_rsa` (NB: investigate the SSH key situation to see if
+there’s an easier way to get this set-up correctly.) In this example
+we’ll name our key-pair “alice-key”. Come up with a unique cluster
+name like “alice-cluster”. Finally put these values into a tfvars file:
+
+[0]: https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#KeyPairs:
+
+    $ cat > myenv.tfvars <<EOF
+    ssh_key_name = "alice-key"
+    cluster_name = "alice-cluster"
+    EOF
+
+There are other configuration variables available, there’s an example tfvars
+file env.tfvars.example. You can then apply your config:
+
     terraform apply -var-file myenv.tfvars
 
 This will create a new VPC and a one-node Kubernetes cluster in it with kip, and show the public IP address of the node when done:
@@ -35,7 +56,8 @@ You can now ssh into the instance using the username "ubuntu", and the ssh key y
     ip-10-0-26-113.ec2.internal   Ready    master   67s   v1.17.3
     kip-provider-0                Ready    agent    13s   v1.14.0-vk-v0.0.1-125-g3b2cc98
 
-If you haven't set an existing ssh key in your configuration, a new ssh key has been created. You can extract and use it via:
+If you haven't set an existing ssh key in your configuration, a new ssh key has been created.
+You can extract and use it via:
 
     $ terraform show -json | jq -r '.values.root_module.resources | .[] | select(.address=="tls_private_key.ssh-key") | .values.private_key_pem' > /tmp/id_rsa
     $ ssh -i /tmp/id_rsa ubuntu@<public IP of node>

--- a/deploy/terraform-gcp/README.md
+++ b/deploy/terraform-gcp/README.md
@@ -1,19 +1,36 @@
 # Provision a GCP Test Cluster
 
-The Terraform config here can be used to provision a simple test cluster with Kip on GCP.
+The Terraform config here can be used to provision a simple test cluster
+with Kip on GCP.
 
 ## Getting Started
 
 You need:
+
 * a GCP account configured and the necessary services enabled
 * kustomize >= 3.0.0
 * kubectl >= 1.14
 * Terraform >= 0.12
+* google-cloud-sdk >= 321 (older versions may work)
 
-You can then apply your config:
+Then create your configuration:
 
-    cp env.tfvars.example myenv.tfvars
-    vi myenv.tfvars # You can change settings for your cluster here.
+    $ cat > myenv.tfvars <<EOF
+    # name of GCP Project
+    project = "my-project"
+
+    # Cluster name.
+    cluster_name = "alice"
+
+    # Region and zone to create resources in.
+    region = "us-central1"
+    zone = "us-central1-c"
+    EOF
+
+There’s a sample tfvars file in deploy/terraform-gcp/env.tfvars.example.
+
+Run apply to provision the Kubernetes dataplane and the virtual-kubelet:
+
     terraform apply -var-file myenv.tfvars
 
 This will create a new GKE cluster and deploy Kip:
@@ -25,9 +42,12 @@ This will create a new GKE cluster and deploy Kip:
 
 ## Run a Pod via Virtual Kubelet
 
-The node taint in kip is disabled in the manifest, so Kubernetes will try to run all pods via the virtual node.
+The node taint in kip is disabled in the manifest, so Kubernetes will try
+to run all pods via the virtual node.
 
-If you decide to enable the taint on the virtual node (via removing the `--disable-taint` command line flag), you will need to add a toleration and/or node selector for pods that are meant to run via kip:
+To enable taint on the virtual node: remove the `--disable-taint` command
+line flag. Then add a toleration or node selector for pods that are meant
+to run via kip:
 
     spec:
       nodeSelector:

--- a/deploy/terraform-gcp/main.tf
+++ b/deploy/terraform-gcp/main.tf
@@ -1,17 +1,19 @@
 terraform {
   required_version = ">= 0.12.0"
-}
-
-provider "null" {
-  version =  "~> 2.1"
-}
-
-provider "random" {
-  version =  "~> 2.2"
+  required_providers {
+    null = {
+      version = "~> 2.1"
+    }
+    random = {
+      version = "~> 2.2"
+    }
+    google = {
+      version = "~> 3.21"
+    }
+  }
 }
 
 provider "google" {
-  version = "~> 3.21"
   project = var.project
   region  = var.region
   zone    = var.zone


### PR DESCRIPTION
Still work in progress. I did AWS, and GCE will be next.

Closes #196

Update Terraform configuration files to support 0.13+. The maintainers have deprecated a few things like referencing external variables from a destroy provisioner.