### PR TITLE
Fix my first bug: bad terminate-instances command

### DIFF
--- a/deploy/terraform-aws/cleanup-vpc.sh
+++ b/deploy/terraform-aws/cleanup-vpc.sh
@@ -55,9 +55,13 @@ get_pending_and_running_instance_ids_by_vpc_id() {
 instance_ids=$(get_pending_and_running_instance_ids_by_vpc_id "$VPC_ID")
 while [[ -n "$instance_ids" ]]
 do
-    echo "Terminating instances: $instance_ids"
-    aws ec2 terminate-instances --instance-ids "$instance_ids"
-    aws ec2 wait instance-terminated --instance-ids "$instance_ids"
+    for instance_id in $instance_ids
+    do
+        echo "Terminating instance: $instance_id"
+        aws ec2 terminate-instances --instance-ids "$instance_id"
+        aws ec2 wait instance-terminated --instance-ids "$instance_id"
+        echo "Instance $instance_id terminated"
+    done
 
     # Update the list to ensure nothing else came up in the VPC that would
     # block the destruction of the security group.


### PR DESCRIPTION
Because I quoted the variable instance_ids in the terminate-instance for loop, cleanup-vpc.sh doesn’t work with more than one instance. This PR fixes this by using a loop to properly expand the IDS.

I didn’t see this bug during my tests because I didn’t add any pod to the cluster.

Here’s the log of the error:

```
null_resource.gw (local-exec): An error occurred (InvalidInstanceID.Malformed) when calling the TerminateInstances operation: Invalid id: "i-026d5801edec31980
null_resource.gw (local-exec): i-0280cd2a27136b5ac"

null_resource.main (local-exec): An error occurred (InvalidInstanceID.Malformed) when calling the TerminateInstances operation: Invalid id: "i-026d5801edec31980
null_resource.main (local-exec): i-0280cd2a27136b5ac"

null_resource.gw (local-exec): Waiter InstanceTerminated failed: Invalid id: "i-026d5801edec31980
null_resource.gw (local-exec): i-0280cd2a27136b5ac"

null_resource.main (local-exec): Waiter InstanceTerminated failed: Invalid id: "i-026d5801edec31980
null_resource.main (local-exec): i-0280cd2a27136b5ac"
null_resource.main (local-exec): Terminating instances: i-026d5801edec31980
null_resource.main (local-exec): i-0280cd2a27136b5ac
null_resource.gw (local-exec): Terminating instances: i-026d5801edec31980
null_resource.gw (local-exec): i-0280cd2a27136b5ac
```