### PR TITLE
Add SAN to client certificate to fix Kip built with 1.15 with EC2 instances.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Override the GO variable to test with a different version of Golang:
+#     $ make GO=/usr/lib/go-1.15/bin/go
+GO=go
 DKR=docker
 GIT_VERSION=$(shell git describe --dirty)
 CURRENT_TIME=$(shell date +%Y%m%d%H%M%S)
@@ -21,7 +24,7 @@ GENERATED_SRC=$(TOP_DIR)pkg/clientapi/clientapi.pb.go \
 all: $(BINARIES)
 
 kip: $(PKG_SRC) $(CMD_SRC) $(GENERATED_SRC) $(MODULE_FILES)
-	CGO_ENABLED=0 go build $(LDFLAGS) -o $(TOP_DIR)$@ $(TOP_DIR)cmd/kip
+	CGO_ENABLED=0 $(GO) build $(LDFLAGS) -o $(TOP_DIR)$@ $(TOP_DIR)cmd/kip
 
 
 $(TOP_DIR)pkg/clientapi/clientapi.pb.go: $(TOP_DIR)pkg/clientapi/clientapi.proto
@@ -34,7 +37,7 @@ $(TOP_DIR)pkg/api/deepcopy_generated.go: $(TOP_DIR)pkg/api/types.go
 
 # kipctl is compiled staticly so it'll run on pods
 kipctl: $(PKG_SRC) $(KIPCTL_SRC) $(MODULE_FILES)
-	cd cmd/kipctl && CGO_ENABLED=0 GOOS=linux go build $(LDFLAGS) -o $(TOP_DIR)kipctl
+	cd cmd/kipctl && CGO_ENABLED=0 GOOS=linux $(GO) build $(LDFLAGS) -o $(TOP_DIR)kipctl
 
 img: $(BINARIES)
 	@echo "Checking if IMAGE_TAG is set" && test -n "$(IMAGE_TAG)"
@@ -55,9 +58,9 @@ clean:
 .PHONY: all clean
 
 pricing-updater:
-	cd scripts/update_instance_data/pricing-updater/cmd  && go build $(LDFLAGS) -o $(TOP_DIR)scripts/update_instance_data/pricing-updater/pricing-updater
+	cd scripts/update_instance_data/pricing-updater/cmd  && $(GO) build $(LDFLAGS) -o $(TOP_DIR)scripts/update_instance_data/pricing-updater/pricing-updater
 
 update-pricing-data: pricing-updater
 	echo "scraping data for all providers"
 	cd scripts/update_instance_data/pricing-updater/ && ./pricing-updater -scrape-all
-	cd scripts/update_instance_data/pricing-updater/scripts && pwd && TOP_KIP_DIR=$(TOP_DIR) go generate
+	cd scripts/update_instance_data/pricing-updater/scripts && pwd && TOP_KIP_DIR=$(TOP_DIR) $(GO) generate

--- a/deploy/terraform-aws/cleanup-vpc.sh
+++ b/deploy/terraform-aws/cleanup-vpc.sh
@@ -55,9 +55,13 @@ get_pending_and_running_instance_ids_by_vpc_id() {
 instance_ids=$(get_pending_and_running_instance_ids_by_vpc_id "$VPC_ID")
 while [[ -n "$instance_ids" ]]
 do
-    echo "Terminating instances: $instance_ids"
-    aws ec2 terminate-instances --instance-ids "$instance_ids"
-    aws ec2 wait instance-terminated --instance-ids "$instance_ids"
+    for instance_id in $instance_ids
+    do
+        echo "Terminating instance: $instance_id"
+        aws ec2 terminate-instances --instance-ids "$instance_id"
+        aws ec2 wait instance-terminated --instance-ids "$instance_id"
+        echo "Instance $instance_id terminated"
+    done
 
     # Update the list to ensure nothing else came up in the VPC that would
     # block the destruction of the security group.

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -55,11 +55,11 @@ func createCertHelper(certTemplate, parentCert *x509.Certificate, pubKey, privKe
 func CreateRootCert(privateKey *ecdsa.PrivateKey) (*x509.Certificate, error) {
 	name := pkix.Name{CommonName: "Milpa Server CA"}
 	certTemplate := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject:      name,
-		NotBefore:    time.Now().Add(-600 * time.Second).UTC(),
-		NotAfter:     time.Now().Add(time.Duration(10*24*365) * time.Hour).UTC(),
-		IsCA:         true,
+		SerialNumber:          big.NewInt(1),
+		Subject:               name,
+		NotBefore:             time.Now().Add(-600 * time.Second).UTC(),
+		NotAfter:              time.Now().Add(time.Duration(10*24*365) * time.Hour).UTC(),
+		IsCA:                  true,
 		BasicConstraintsValid: true,
 		KeyUsage: x509.KeyUsageKeyEncipherment |
 			x509.KeyUsageDataEncipherment |

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -93,6 +93,7 @@ func CreateCert(rootCert *x509.Certificate, rootPrivateKey *ecdsa.PrivateKey, se
 			Country:            []string{"United States"},
 			CommonName:         commonName, // used for client verification
 		},
+		DNSNames:     []string{commonName},
 		NotBefore:    time.Now(),
 		NotAfter:     time.Now().AddDate(10, 0, 0),
 		SubjectKeyId: []byte{1, 2, 3, 4, 6},


### PR DESCRIPTION
Should fix #176 
Unfortunately I couldn’t reproduce the bug with go 1.13. 