### PR TITLE
Dedicated Host fixes

### DIFF
--- a/pkg/server/cloud/aws/instances.go
+++ b/pkg/server/cloud/aws/instances.go
@@ -414,6 +414,9 @@ func (e *AwsEC2) retrieveOrAllocateHost(node *api.Node) (*string, error) {
 			}, {
 				Name:   aws.String("instance-type"),
 				Values: aws.StringSlice([]string{node.Spec.InstanceType}),
+			}, {
+				Name:   aws.String("availability-zone"),
+				Values: aws.StringSlice([]string{e.availabilityZone}),
 			},
 		},
 	})

--- a/pkg/server/nodemanager/node_controller.go
+++ b/pkg/server/nodemanager/node_controller.go
@@ -42,7 +42,8 @@ import (
 // Making these vars makes it easier testing
 // non-const timeouts were endorsed by Mitchell Hashimoto
 var (
-	BootTimeout         time.Duration = 300 * time.Second
+	//	BootTimeout         time.Duration = 300 * time.Second
+	BootTimeout         time.Duration = 15 * time.Minute
 	HealthyTimeout      time.Duration = 90 * time.Second
 	HealthcheckPause    time.Duration = 5 * time.Second
 	SpotRequestPause    time.Duration = 60 * time.Second


### PR DESCRIPTION
**Updates:**
- Add AZ targeting support when finding dedicated hosts
- Increase boot timeout so mac instances are not prematurely purged if they take a longer period of time to boot. 