### PR TITLE
kustomize overlay for running mac workloads

### DIFF
--- a/deploy/manifests/kip/overlays/mac-tests/README.md
+++ b/deploy/manifests/kip/overlays/mac-tests/README.md
@@ -1,0 +1,97 @@
+# Minimum IAM permissions
+Permissions required for using SSM store:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Deny",
+            "Action": "ssm:GetParametersByPath",
+            "Resource": "arn:aws:ssm:us-west-2:689494258501:parameter/kip/cells/*"
+        },
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter"
+            ],
+            "Resource": "arn:aws:ssm:us-west-2:689494258501:parameter/kip/cells/*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/AWSUserID": "${aws:userid}"
+                }
+            }
+        },
+        {
+            "Sid": "",
+            "Effect": "Deny",
+            "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter"
+            ],
+            "Resource": "arn:aws:ssm:us-west-2:689494258501:parameter/kip/cells/*",
+            "Condition": {
+                "StringNotEquals": {
+                    "aws:ResourceTag/AWSUserID": "${aws:userid}"
+                }
+            }
+        }
+    ]
+}
+```
+and minimum KIP permissions:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ec2",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AssociateIamInstanceProfile",
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:CreateRoute",
+                "ec2:CreateSecurityGroup",
+                "ec2:CreateTags",
+                "ec2:DeleteRoute",
+                "ec2:DeleteSecurityGroup",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeDhcpOptions",
+                "ec2:DescribeIamInstanceProfileAssociations",
+                "ec2:DescribeImages",
+                "ec2:DescribeInstances",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeRouteTables",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeVolumes",
+                "ec2:DescribeVolumesModifications",
+                "ec2:DescribeVpcs",
+                "ec2:ModifyInstanceAttribute",
+                "ec2:ModifyInstanceCreditSpecification",
+                "ec2:ModifyVolume",
+                "ec2:ReplaceIamInstanceProfileAssociation",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:RunInstances",
+                "ec2:TerminateInstances",
+                "ecr:BatchGetImage",
+                "ecr:GetAuthorizationToken",
+                "ecr:GetDownloadUrlForLayer",
+                "iam:GetInstanceProfile",
+                "iam:PassRole",
+                "ssm:AddTagsToResource",
+                "ssm:DeleteParameters",
+                "ssm:GetParameter",
+                "ssm:GetParameters",
+                "ssm:GetParametersByPath",
+                "ssm:PutParameter"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+# Recommended IAM permissions with debugging capabilities
+Two above and `AmazonSSMManagedInstanceCore`.

--- a/deploy/manifests/kip/overlays/mac-tests/kustomization.yaml
+++ b/deploy/manifests/kip/overlays/mac-tests/kustomization.yaml
@@ -1,0 +1,10 @@
+bases:
+  - ../../base
+patchesStrategicMerge:
+  - statefulset.yaml
+configMapGenerator:
+  - name: config
+    behavior: merge
+    files:
+      - cloudinit.yaml
+      - provider.yaml

--- a/deploy/manifests/kip/overlays/mac-tests/provider.yaml
+++ b/deploy/manifests/kip/overlays/mac-tests/provider.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+etcd:
+  internal:
+    dataDir: /opt/kip/data
+cells:
+  defaultVolumeSize: "600G"
+  defaultIAMPermissions: "kip-mac-ssm"
+  defaultInstanceType: "t3.nano"
+  useCloudParameterStore: true
+  nametag: kip
+  bootImageSpec:
+    imageIDs: ami-051d588cea9ac504a
+  cellConfig:
+    itzoFlag-use-anka: true
+  itzo:
+    url: https://itzo-kip-dev-download.s3.amazonaws.com
+    version: darwin-876

--- a/deploy/manifests/kip/overlays/mac-tests/statefulset.yaml
+++ b/deploy/manifests/kip/overlays/mac-tests/statefulset.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: provider
+spec:
+  template:
+    spec:
+      containers:
+        - name: kip
+          image: elotl/kip:v1.0.6-82-g424d918
+      volumes:
+      - name: provider-yaml
+        configMap:
+          name: config
+          items:
+          - key: cloudinit.yaml
+            path: cloudinit.yaml
+            mode: 0600
+          - key: provider.yaml
+            path: provider.yaml
+            mode: 0600


### PR DESCRIPTION
This is a setup I've been using for e2e tests with mac1.metal. Probably we should wait with merging this one until we have other changes in kip & itzo merged, so we can use non-dev versions of those two.