### PR TITLE
Fix apt key in terraform-aws

### DIFF
--- a/deploy/terraform-aws/node.sh
+++ b/deploy/terraform-aws/node.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6A030B21BA07F4FB
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF


### PR DESCRIPTION
Probably the GPG key used for signing the k8s packages has changed.
Fetch and install the correct one before installing k8s packages.