### PR TITLE
duplicate controls around boot image for ARM64 AMIs

### DIFF
--- a/docs/provider-config.md
+++ b/docs/provider-config.md
@@ -135,6 +135,7 @@ cells:
 
   # bootImageSpec is a dictionary of cloud-specific image properties for
   # specifying the boot image to use for cells.
+  # Image specified here has to be built from x86_64 OS. For ARM64 images, see arm64BootImageSpec.
   # Valid fields on AWS are:
   #   - owners, which is a space separated list of AWS account IDs, "self", or
   #     an AWS owner alias such as "amazon" or "aws-marketplace".
@@ -154,6 +155,15 @@ cells:
   bootImageSpec:
     owners: "689494258501"
     filters: "name=elotl-kip-*"
+    architecture: "x86_64"
+  
+  # specifying arm64BootImageSpec will allow you to consume AWS EC2 instances with ARM CPUs.
+  # configuration of this field is exactly a same as bootImageSpec above. 
+  # The below settings are the default if no arm64BootImageSpec is specified.
+  arm64BootImageSpec:
+    owners: "689494258501"
+    filters: "name=elotl-kip-*"
+    architecture: "arm64"
 
   # cloudInitFile specifies a path to a cloudInitFile that will be
   # used to provision all cells that Kip boots. Kip will detect

--- a/pkg/server/cloud/aws/aws_functional_test.go
+++ b/pkg/server/cloud/aws/aws_functional_test.go
@@ -36,6 +36,7 @@ const (
 	vpcID            = "vpc-841834e2"
 	defaultSubnetID  = "subnet-12a8a13f"
 	imageAmi         = "ami-e2dea19d"
+	imageARMAmi      = "ami-02316a849a44166f1"
 	rootDevice       = "xvda" // Update if imageAmi is changed.
 	instanceType     = "t2.nano"
 )
@@ -124,7 +125,10 @@ func TestAWSCloud(t *testing.T) {
 		AWSContainerAuthTest(t, ts.CloudClient)
 	})
 	t.Run("BootSpotInstanceTest", func(t *testing.T) {
-		functional.RunSpotInstanceTest(t, ts.CloudClient, imageAmi, rootDevice)
+		functional.RunSpotInstanceTest(t, ts.CloudClient, imageAmi, "t3.micro", rootDevice)
+	})
+	t.Run("BootSpotARM64InstanceTest", func(t *testing.T) {
+		functional.RunSpotInstanceTest(t, ts.CloudClient, imageARMAmi, "t4g.micro", rootDevice)
 	})
 }
 

--- a/pkg/server/cloud/aws/ec2_arm_instance_types.go
+++ b/pkg/server/cloud/aws/ec2_arm_instance_types.go
@@ -1,0 +1,24 @@
+package aws
+
+import "strings"
+
+var ARMInstanceTypes = []string{
+	"t4g.",
+	"c6g.",
+	"c6gd.",
+	"c6gn.",
+	"m6g.",
+	"m6gd.",
+	"r6g.",
+	"r6gd.",
+	"x2gd.",
+}
+
+func checkInstanceTypeArch(instanceType string) string {
+	for _, instanceFamilyPrefix := range ARMInstanceTypes {
+		if strings.HasPrefix(instanceType, instanceFamilyPrefix) {
+			return arm64BootImageArch
+		}
+	}
+	return defaultBootImageArch
+}

--- a/pkg/server/cloud/aws/instances_test.go
+++ b/pkg/server/cloud/aws/instances_test.go
@@ -17,22 +17,9 @@ func TestBootImageSpecToDescribeImagesInput(t *testing.T) {
 		Input ec2.DescribeImagesInput
 	}{
 		{
-			name: "default boot image spec",
-			Spec: cloud.BootImageSpec{},
-			Input: ec2.DescribeImagesInput{
-				Owners: aws.StringSlice([]string{elotlOwnerID}),
-				Filters: []*ec2.Filter{
-					{
-						// this is added by default if any filters are specified and arch is not specified
-						Name: aws.String("architecture"),
-						Values: aws.StringSlice([]string{defaultBootImageArch}),
-					},
-					{
-						Name:   aws.String("name"),
-						Values: aws.StringSlice([]string{elotlImageNameFilter}),
-					},
-				},
-			},
+			name:  "default boot image spec",
+			Spec:  cloud.BootImageSpec{},
+			Input: *defaultx86_64_BootImageInput,
 		},
 		{
 			name: "only filters specified",
@@ -79,6 +66,13 @@ func TestBootImageSpecToDescribeImagesInput(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "edge case: no arm64BootImageSpec specified, only architecture",
+			Spec: cloud.BootImageSpec{
+				"arch": "arm64",
+			},
+			Input: *defaultARM64_BootImageInput,
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/server/cloud/azure/instances.go
+++ b/pkg/server/cloud/azure/instances.go
@@ -150,7 +150,7 @@ func (az *AzureClient) createNIC(instanceID string, ipID string) (string, error)
 	return to.String(nic.ID), nil
 }
 
-func (az *AzureClient) StartNode(node *api.Node, image cloud.Image, metadata, iamPermissions string) (string, error) {
+func (az *AzureClient) StartNode(node *api.Node, image cloud.Image, _ cloud.Image, metadata, iamPermissions string) (string, error) {
 	klog.V(2).Infof("Starting instance for node: %v", node)
 	instanceID := makeInstanceID(az.controllerID, node.Name)
 	err := az.createResourceGroup(instanceID)
@@ -265,14 +265,14 @@ func (az *AzureClient) ReleaseDedicatedHosts() error {
 	return fmt.Errorf("Azure: %s", "release dedicated hosts not implemented yet")
 }
 
-func (az *AzureClient) StartDedicatedNode(node *api.Node, image cloud.Image, metadata, iamPermissions string) (string, error) {
+func (az *AzureClient) StartDedicatedNode(node *api.Node, image cloud.Image, _ cloud.Image, metadata, iamPermissions string) (string, error) {
 	// TODO stubbed not implemented yet
 	return "", fmt.Errorf("Azure: %s", "start dedicated node not implemented yet")
 
 }
 
-func (az *AzureClient) StartSpotNode(node *api.Node, image cloud.Image, metadata, iamPermissions string) (string, error) {
-	return az.StartNode(node, image, metadata, iamPermissions)
+func (az *AzureClient) StartSpotNode(node *api.Node, image cloud.Image, imageARM cloud.Image, metadata, iamPermissions string) (string, error) {
+	return az.StartNode(node, image, imageARM, metadata, iamPermissions)
 }
 
 func (az *AzureClient) getNodeTags(node *api.Node) map[string]*string {

--- a/pkg/server/cloud/cloud.go
+++ b/pkg/server/cloud/cloud.go
@@ -45,9 +45,9 @@ const InstanceParameterCertificate = "certificate"
 type CloudClient interface {
 	SetBootSecurityGroupIDs([]string)
 	GetBootSecurityGroupIDs() []string
-	StartNode(*api.Node, Image, string, string) (string, error)
-	StartSpotNode(*api.Node, Image, string, string) (string, error)
-	StartDedicatedNode(*api.Node, Image, string, string) (string, error)
+	StartNode(*api.Node, Image, Image, string, string) (string, error)
+	StartSpotNode(*api.Node, Image, Image, string, string) (string, error)
+	StartDedicatedNode(*api.Node, Image, Image, string, string) (string, error)
 	// This should always be called from a goroutine as it can take a while
 	StopInstance(instanceID string) error
 	ReleaseDedicatedHosts() error

--- a/pkg/server/cloud/functional/functional_test_template.go
+++ b/pkg/server/cloud/functional/functional_test_template.go
@@ -75,7 +75,7 @@ func (ts *TestState) startNodes(img cloud.Image) error {
 	for _, node := range nodes {
 		go func(n *api.Node) {
 			fmt.Println("starting node", n.Name)
-			instanceID, err := ts.CloudClient.StartNode(n, img, "", "")
+			instanceID, err := ts.CloudClient.StartNode(n, img, img, "", "")
 			if err != nil {
 				startResults <- err
 				return
@@ -132,7 +132,7 @@ func RunSpotInstanceTest(t *testing.T, c cloud.CloudClient, imageID, rootDevice 
 		ID:         imageID,
 		RootDevice: rootDevice,
 	}
-	instanceID, err := c.StartSpotNode(spotNode, img, "", "")
+	instanceID, err := c.StartSpotNode(spotNode, img, img, "", "")
 	if err != nil {
 		msg := fmt.Sprintf("Failed to Start Spot Node, failing test %s", err)
 		assert.Fail(t, msg)

--- a/pkg/server/cloud/functional/functional_test_template.go
+++ b/pkg/server/cloud/functional/functional_test_template.go
@@ -121,12 +121,12 @@ func SetupFirewallRules(t *testing.T, c cloud.CloudClient) error {
 	return err
 }
 
-func RunSpotInstanceTest(t *testing.T, c cloud.CloudClient, imageID, rootDevice string) {
+func RunSpotInstanceTest(t *testing.T, c cloud.CloudClient, imageID, instanceType, rootDevice string) {
 	fmt.Printf("Booting spot instance\n")
 	spotNode := api.GetFakeNode()
 	// For the last 3 months there has always been an AZ in us-east-1
 	// that can boot an m3.medium spot instance.
-	spotNode.Spec.InstanceType = "t3.micro"
+	spotNode.Spec.InstanceType = instanceType
 	spotNode.Spec.BootImage = imageID
 	img := cloud.Image{
 		ID:         imageID,

--- a/pkg/server/cloud/gce/instances.go
+++ b/pkg/server/cloud/gce/instances.go
@@ -283,7 +283,7 @@ func (c *gceClient) startNode(node *api.Node, image cloud.Image, metadata, iamPe
 	return spec.Name, nil
 }
 
-func (c *gceClient) StartNode(node *api.Node, image cloud.Image, metadata, iamPermissions string) (string, error) {
+func (c *gceClient) StartNode(node *api.Node, image cloud.Image, _ cloud.Image, metadata, iamPermissions string) (string, error) {
 	return c.startNode(node, image, metadata, iamPermissions)
 }
 
@@ -292,7 +292,7 @@ func (c *gceClient) ReleaseDedicatedHosts() error {
 	return fmt.Errorf("GCP: %s", "release dedicated hosts not implemented yet")
 }
 
-func (c *gceClient) StartDedicatedNode(node *api.Node, image cloud.Image, metadata, iamPermissions string) (string, error) {
+func (c *gceClient) StartDedicatedNode(node *api.Node, image cloud.Image, imageARM cloud.Image, metadata, iamPermissions string) (string, error) {
 	// TODO stubbed not implemented yet
 	return "", fmt.Errorf("GCP: %s", "start dedicated node not implemented yet")
 }
@@ -300,7 +300,7 @@ func (c *gceClient) StartDedicatedNode(node *api.Node, image cloud.Image, metada
 // In we dictate whether the node is a spot based on the node passed in
 // this is decided in createInstanceSpec which is called in the unexported
 // startNode function. StartSpotNode is necessary to fullfil the interface.
-func (c *gceClient) StartSpotNode(node *api.Node, image cloud.Image, metadata, iamPermissions string) (string, error) {
+func (c *gceClient) StartSpotNode(node *api.Node, image cloud.Image, _ cloud.Image, metadata, iamPermissions string) (string, error) {
 	return c.startNode(node, image, metadata, iamPermissions)
 }
 

--- a/pkg/server/cloud/mock.go
+++ b/pkg/server/cloud/mock.go
@@ -33,9 +33,9 @@ type MockCloudClient struct {
 	VPCCIDRs     []string
 	Subnet       SubnetAttributes
 
-	Starter             func(node *api.Node, image Image, metadata, iamPermissions string) (string, error)
-	SpotStarter         func(node *api.Node, image Image, metadata, iamPermissions string) (string, error)
-	DedicatedStarter    func(node *api.Node, image Image, metadata, iamPermissions string) (string, error)
+	Starter             func(node *api.Node, image Image, armImg Image, metadata, iamPermissions string) (string, error)
+	SpotStarter         func(node *api.Node, image Image, armImg Image, metadata, iamPermissions string) (string, error)
+	DedicatedStarter    func(node *api.Node, image Image, armImg Image, metadata, iamPermissions string) (string, error)
 	Stopper             func(instanceID string) error
 	Releaser            func() error
 	Waiter              func(node *api.Node) ([]api.NetworkAddress, error)
@@ -82,16 +82,16 @@ func (m *MockCloudClient) GetBootSecurityGroupIDs() []string {
 	return nil
 }
 
-func (m *MockCloudClient) StartNode(node *api.Node, image Image, metadata, iamPermissions string) (string, error) {
-	return m.Starter(node, image, metadata, iamPermissions)
+func (m *MockCloudClient) StartNode(node *api.Node, image, armImg Image, metadata, iamPermissions string) (string, error) {
+	return m.Starter(node, image, armImg, metadata, iamPermissions)
 }
 
-func (m *MockCloudClient) StartSpotNode(node *api.Node, image Image, metadata, iamPermissions string) (string, error) {
-	return m.SpotStarter(node, image, metadata, iamPermissions)
+func (m *MockCloudClient) StartSpotNode(node *api.Node, image, armImg Image, metadata, iamPermissions string) (string, error) {
+	return m.SpotStarter(node, image, armImg, metadata, iamPermissions)
 }
 
-func (m *MockCloudClient) StartDedicatedNode(node *api.Node, image Image, metadata, iamPermissions string) (string, error) {
-	return m.DedicatedStarter(node, image, metadata, iamPermissions)
+func (m *MockCloudClient) StartDedicatedNode(node *api.Node, image, armImg Image, metadata, iamPermissions string) (string, error) {
+	return m.DedicatedStarter(node, image, armImg, metadata, iamPermissions)
 }
 
 func (m *MockCloudClient) StopInstance(instanceID string) error {
@@ -322,7 +322,7 @@ func NewMockClient() *MockCloudClient {
 		return []string{"cloud.internal"}, []string{"1.1.1.1"}, nil
 	}
 
-	net.Starter = func(node *api.Node, image Image, metadata, iamPermissions string) (string, error) {
+	net.Starter = func(node *api.Node, image Image, armImage Image, metadata, iamPermissions string) (string, error) {
 		inst := CloudInstance{
 			ID:       node.Status.InstanceID,
 			NodeName: node.Name,

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -140,6 +140,7 @@ type InternalEtcdConfig struct {
 
 type CellsConfig struct {
 	BootImageSpec          cloud.BootImageSpec           `json:"bootImageSpec"`
+	ARM64BootImageSpec     cloud.BootImageSpec           `json:"arm64BootImageSpec"`
 	DefaultInstanceType    string                        `json:"defaultInstanceType"`
 	DefaultVolumeSize      string                        `json:"defaultVolumeSize"`
 	StandbyCells           []nodemanager.StandbyNodeSpec `json:"standbyCells"`

--- a/pkg/server/nodemanager/node_controller.go
+++ b/pkg/server/nodemanager/node_controller.go
@@ -47,7 +47,7 @@ import (
 var (
 	// TODO: this was changed to handle mac1.metal boot, ideally we should have different
 	// bootTimeouts depending on instance family
-	BootTimeout         time.Duration = 20 * time.Minute
+	BootTimeout         time.Duration = 5 * time.Minute
 	HealthyTimeout      time.Duration = 90 * time.Second
 	HealthcheckPause    time.Duration = 5 * time.Second
 	SpotRequestPause    time.Duration = 60 * time.Second
@@ -186,12 +186,8 @@ func (c *NodeController) doPoolsCalculation() (map[string]string, error) {
 	// If we can't get the boot image, just use the old value for the image
 	// ARM64
 	if c.ARM64BootImageSpec != nil {
-		armSpec := make(cloud.BootImageSpec, 0)
-		for k, v := range c.ARM64BootImageSpec {
-			armSpec[k] = v
-		}
-		armSpec[bootSpecArchKey] = arm64Architecture
-		newBootImageARM, err := c.imageSpecToImage(armSpec)
+		c.ARM64BootImageSpec[bootSpecArchKey] = arm64Architecture
+		newBootImageARM, err := c.imageSpecToImage(c.ARM64BootImageSpec)
 		if err != nil {
 			if BootImageARM.ID == "" {
 				return nil, util.WrapError(err, "Could not get latest boot image")

--- a/pkg/server/nodemanager/node_scaler.go
+++ b/pkg/server/nodemanager/node_scaler.go
@@ -94,7 +94,7 @@ func (s *BindingNodeScaler) createNodeForPod(pod *api.Pod) *api.Node {
 
 	node := api.NewNode()
 	node.Spec.InstanceType = pod.Spec.InstanceType
-	node.Spec.BootImage = BootImage.ID
+	node.Spec.BootImage = BootImagex86_64.ID
 	node.Spec.Spot = isSpotPod
 	node.Spec.Dedicated = pod.Spec.Dedicated
 	node.Spec.Resources = pod.Spec.Resources
@@ -114,7 +114,7 @@ func (s *BindingNodeScaler) createNodeForPod(pod *api.Pod) *api.Node {
 func (s *BindingNodeScaler) createNodeForStandbySpec(spec *StandbyNodeSpec) *api.Node {
 	node := api.NewNode()
 	node.Spec.InstanceType = spec.InstanceType
-	node.Spec.BootImage = BootImage.ID
+	node.Spec.BootImage = BootImagex86_64.ID
 	node.Spec.Spot = spec.Spot
 	node.Spec.Dedicated = spec.Dedicated
 	node.Spec.Resources.VolumeSize = s.defaultVolumeSize

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -394,6 +394,7 @@ func NewInstanceProvider(configFilePath, nodeName, internalIP, clusterDNS, clust
 		CertificateFactory: certFactory,
 		BootLimiter:        bootLimiter,
 		BootImageSpec:      serverConfigFile.Cells.BootImageSpec,
+		ARM64BootImageSpec: serverConfigFile.Cells.ARM64BootImageSpec,
 	}
 
 	klog.V(5).Infof("creating garbage controller")
@@ -511,7 +512,13 @@ func NewInstanceProvider(configFilePath, nodeName, internalIP, clusterDNS, clust
 	if err != nil {
 		return nil, fmt.Errorf("failed to validate boot image spec")
 	}
-
+	klog.V(5).Infof("validating arm64 boot image spec")
+	err = validateBootImageSpec(
+		serverConfigFile.Cells.ARM64BootImageSpec, cloudClient)
+	if err != nil {
+		klog.Warningf("failed to validate arm64 boot image spec %v", err)
+		err = nil
+	}
 	klog.V(5).Infof("done creating instance provider")
 	return s, err
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -351,7 +351,8 @@ func NewInstanceProvider(configFilePath, nodeName, internalIP, clusterDNS, clust
 	}
 
 	klog.V(5).Infof("creating image ID cache")
-	imageIdCache := timeoutmap.New(false, nil)
+	imageIdCachex86_x64 := timeoutmap.New(false, nil)
+	imageIdCacheARM64 := timeoutmap.New(false, nil)
 
 	klog.V(5).Infof("checking cloud-init file")
 	cloudInitFile, err := cloudinitfile.New(serverConfigFile.Cells.CloudInitFile)
@@ -387,7 +388,8 @@ func NewInstanceProvider(configFilePath, nodeName, internalIP, clusterDNS, clust
 		CloudClient:        cloudClient,
 		NodeClientFactory:  itzoClientFactory,
 		Events:             eventSystem,
-		ImageIdCache:       imageIdCache,
+		ImageIdCachex86_64: imageIdCachex86_x64,
+		ImageIDCacheARM64:  imageIdCacheARM64,
 		CloudInitFile:      cloudInitFile,
 		CertificateFactory: certFactory,
 		BootLimiter:        bootLimiter,


### PR DESCRIPTION
this should allow user to specify `arm64BootImageSpec` field in `provider.yaml` while we keep backwards compatibility. I have to added checking instance CPU architecture before launching it, so we always use correct AMI.

I decided to mostly duplicate functions that control existing AMI; they're already battle tested and I don't see a need to have more generic solution as we probably won't add support for another architecture in foreseeable future.