### PR TITLE
Fix kip smoke test: use docker-ce instead of docker.io in node.sh

### DIFF
--- a/deploy/terraform-aws/node.sh
+++ b/deploy/terraform-aws/node.sh
@@ -3,7 +3,7 @@
 set -e
 
 apt-get update
-apt-get install apt-transport-https ca-certificates curl gnupg lsb-release
+apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main

--- a/deploy/terraform-aws/node.sh
+++ b/deploy/terraform-aws/node.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 apt-get update
 apt-get install apt-transport-https ca-certificates curl gnupg lsb-release
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
@@ -75,7 +77,6 @@ kubernetesVersion: "$k8s_version"
 EOF
 kubeadm config migrate --old-config /tmp/old-kubeadm-config.yaml --new-config /tmp/kubeadm-config.yaml
 kubeadm init --config=/tmp/kubeadm-config.yaml
-stat /etc/kubernetes/admin.conf
 
 export KUBECONFIG=/etc/kubernetes/admin.conf
 

--- a/scripts/run_smoke_test.sh
+++ b/scripts/run_smoke_test.sh
@@ -59,7 +59,7 @@ create_cluster() {
     pushd $TFDIR
     cat > main.tf <<EOF
 terraform {
-  required_version = "~> 0.12"
+  required_version = ">= 0.12.0"
   backend "s3" {
     region  = "${USE_REGION}"
     bucket  = "${STATE_BUCKET}"
@@ -99,7 +99,7 @@ run_smoke_test() {
     kubectl run nginx --image=nginx --port=80
     kubectl expose pod nginx
     kubectl run test --restart=Never --image=elotl/debug --command -- /bin/sh -c "$curlcmd"
-    timeout 300s bash -c "$waitcmd"
+    timeout 360s bash -c "$waitcmd"
 }
 
 fetch_kubeconfig() {

--- a/scripts/run_smoke_test.sh
+++ b/scripts/run_smoke_test.sh
@@ -99,7 +99,7 @@ run_smoke_test() {
     kubectl run nginx --image=nginx --port=80
     kubectl expose pod nginx
     kubectl run test --restart=Never --image=elotl/debug --command -- /bin/sh -c "$curlcmd"
-    timeout 360s bash -c "$waitcmd"
+    timeout 420s bash -c "$waitcmd"
 }
 
 fetch_kubeconfig() {


### PR DESCRIPTION
Our `/terraform-aws` setup start failing due to the [docker bug](https://github.com/moby/moby/issues/41890). To fix it, I switched `docker.io` (which is no longer recommened package AFAIC) to `docker-ce` based on install instruction from [official docker docs](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository). Also fixed deprecation warning about api version of`InitConfiguration` in `kubeadm init`.