### PR TITLE
add signerName to CSR - closes #235

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   - AWS_REGION=us-east-1
   - AWS_DEFAULT_REGION=us-east-1
   - TERRAFORM_VERSION=0.12.21
-  - KUBECTL_VERSION=1.18.0
+  - KUBECTL_VERSION=1.19.0
   - KUSTOMIZE_VERSION=3.6.1
   - GOOGLE_APPLICATION_CREDENTIALS=.account.json
   - secure: eQV5LiSp5XP7pL4gFYR98uL8aMdmeI5J5h3oOsRZ8fEBVFB0XBX0QDmK6zpaxAx2GoHfFC6ioUdNQjiVmnatwRHnnmxlplD8w99LXcvYkdfS6mtbyhdd2gZNv3gypIFqzyG73zqqhosNSUou1H8GSMWaQSk+P1Y6W7jHKsPEtrV5fepwu6tSpIK+DZbN2mrbyKdKMgWkdAPd/ni++bLDrvwlsoC8MOyWLerDnjRdC/Enzp4OgP9XR/JcqaNyXGLhMRLrN/PwWUk6mayjiVdGk9MLM+YuzCaVaqmtlHZMQHQQzP8r8KO4wZt+ApfNkVlwj44+ya7YoMkSguS5U4AmC0I3NntwhA4L8tpezk/FhSF0FwmP2MDKbWajYWtptThoXRQ5yU/UTJD/hWPofZPm9halZs7yqtoYNLXQWGfS06zROMyLoDOI7uw8b3VSSxQwVjcy8zjmJ/X5I/Dpl/QXsFGaU3u3u/Q0gE4V7ve/9fhbcittq1pRamcVvvZE/jUiXxWEiVEQ39W2dF/Fsp71nvm9Q7vTkgFKPtZV+lwFykTf9gg8vdbRTJ2qlYz668mQ0B+XUhueR+gxaDV+pIFKHRM+/B32fakTwBkXFHGtonodSL8TCeOydpmWLzJ4KexHAjL9AaUoqj4XKfQtAmtNppPmHpScONfhEZ65V+EnXiE=
@@ -45,7 +45,7 @@ script:
 - "./scripts/run_tests.sh"
 - make img login-img push-img DKR=docker
 - "./scripts/init-cert/build.sh"
-- "./scripts/run_smoke_test.sh"
+- K8S_VERSION=$KUBECTL_VERSION "./scripts/run_smoke_test.sh"
 - "./scripts/update_latest_tags.sh"
 notifications:
   slack:

--- a/deploy/manifests/kip/base/sa.yaml
+++ b/deploy/manifests/kip/base/sa.yaml
@@ -111,6 +111,7 @@ rules:
     - certificates.k8s.io
     resourceNames:
       - kubernetes.io/kubelet-serving
+      - kubernetes.io/legacy-unknown
     resources:
       - signers
     verbs:

--- a/scripts/init-cert/csr/csr.yaml
+++ b/scripts/init-cert/csr/csr.yaml
@@ -3,6 +3,7 @@ kind: CertificateSigningRequest
 metadata:
   name: ${CSR_NAME}
 spec:
+  signerName: kubernetes.io/legacy-unknown
   groups:
   - system:nodes
   - system:authenticated

--- a/scripts/init-cert/kubectl.sh
+++ b/scripts/init-cert/kubectl.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 kubectl_dir_base=/opt/kubectl
-default_kubectl=${kubectl_dir_base}/1.16/kubectl
+default_kubectl=${kubectl_dir_base}/1.19/kubectl
 
 version_doc="$($default_kubectl version --output=json | jq -r '.serverVersion')"
 

--- a/scripts/run_smoke_test.sh
+++ b/scripts/run_smoke_test.sh
@@ -72,6 +72,7 @@ module "kip-aws" {
   source        = "${ROOT_DIR}/deploy/terraform-aws"
   cluster_name  = "${CLUSTER_NAME}"
   k8s_version   = "${K8S_CLUSTER_VERSION}"
+  kustomize_dir = "${ROOT_DIR}/deploy/manifests/kip/base"
 }
 EOF
     terraform init

--- a/scripts/run_smoke_test.sh
+++ b/scripts/run_smoke_test.sh
@@ -5,6 +5,7 @@ ROOT_DIR=$SCRIPT_DIR/..
 
 BUILD=${TRAVIS_BUILD_NUMBER:-local}
 CLUSTER_NAME="build-$BUILD"
+K8S_CLUSTER_VERSION=${K8S_VERSION:-v1.19.0}
 USE_REGION=${USE_REGION:-us-east-1}
 STATE_BUCKET=${STATE_BUCKET:-elotl-tf-state}
 STATE_PATH=${STATE_PATH:-build/terraform-${BUILD}.tfstate}
@@ -70,6 +71,7 @@ terraform {
 module "kip-aws" {
   source        = "${ROOT_DIR}/deploy/terraform-aws"
   cluster_name  = "${CLUSTER_NAME}"
+  k8s_version   = "${K8S_CLUSTER_VERSION}"
 }
 EOF
     terraform init


### PR DESCRIPTION
From EKS docs:

> The CertificateSigningRequest API has been promoted to stable certificates.k8s.io/v1 with the following changes:
spec.signerName is now required. You can't create requests for kubernetes.io/legacy-unknown with the certificates.k8s.io/v1 API.
You can continue to create CSRs with the kubernetes.io/legacy-unknown signer name with the certificates.k8s.io/v1beta1 API.
You can continue to request that a CSR to is signed for a non-node server cert, webhooks, for example, with the certificates.k8s.io/v1beta1 API. These CSRs aren't auto-approved.

I added `signerName: kubernetes.io/legacy-unknown`. Once kubernetes releases v1.22.0 we should consider switching to certificates.k8s.io/v1 API. 
Bumped Kubernetes version in the CI to v1.19.0 as well.