### PR TITLE
Add EKS kustomize overlay and EKS smoke testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
 - "./scripts/run_tests.sh"
 - make img login-img push-img DKR=docker
 - "./scripts/init-cert/build.sh"
-- "./scripts/run_eks_smoke_test.sh"
+- "./scripts/run_eks_smoke_test.sh ./scripts/eks-smoke-test"
 - K8S_VERSION=$KUBECTL_VERSION "./scripts/run_smoke_test.sh"
 - "./scripts/update_latest_tags.sh"
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ script:
 - "./scripts/run_tests.sh"
 - make img login-img push-img DKR=docker
 - "./scripts/init-cert/build.sh"
+- "./scripts/run_eks_smoke_test.sh"
 - K8S_VERSION=$KUBECTL_VERSION "./scripts/run_smoke_test.sh"
 - "./scripts/update_latest_tags.sh"
 notifications:

--- a/deploy/manifests/kip/overlays/aws-eks/kustomization.yaml
+++ b/deploy/manifests/kip/overlays/aws-eks/kustomization.yaml
@@ -1,0 +1,7 @@
+bases:
+  - ../../base
+configMapGenerator:
+  - name: config
+    behavior: merge
+    files:
+      - provider.yaml

--- a/deploy/manifests/kip/overlays/aws-eks/provider.yaml
+++ b/deploy/manifests/kip/overlays/aws-eks/provider.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+cloud:
+  aws:
+    accessKeyID: ""
+    secretAccessKey: ""
+    region: ""
+    vpcID: "" # EKS cluster VPC
+    subnetID: "" # one of cluster VPC subnets, private or public depending whether pod should have access to the internet
+etcd:
+  internal:
+    dataDir: /opt/kip/data
+cells:
+  bootImageSpec:
+    owners: 689494258501
+    filters: name=elotl-kip-*
+  defaultInstanceType: "t3.nano"
+  defaultVolumeSize: "20G"
+  nametag: kip
+  extraSecurityGroups:
+    - "" # paste here all control-plane and workers security groups
+  itzo:
+    url: https://itzo-kip-download.s3.amazonaws.com
+    version: latest
+kubelet:
+  cpu: "100"
+  memory: "512Gi"
+  pods: "200"
+

--- a/docs/running-in-eks.md
+++ b/docs/running-in-eks.md
@@ -1,0 +1,10 @@
+# Running KIP in EKS cluster
+
+It is common use case to use Elastic Kubernetes Cluster by AWS and run KIP inside of it.
+There are few prerequisites:
+1. API server endpoint access has to be set as `Private` or `Public and Private` (you can configure this in AWS console under EKS clusters -> your cluster -> Networking -> Manage networking)
+2. You have to specify `vpcID`, `subnetID` as well as `extraSecurityGroups` in [provider-config](../deploy/manifests/kip/overlays/aws-eks/provider.yaml). vpcID should match your cluster VPC, and cluster control-plane and worker nodes security groups has to be listed under `cells.extraSecurityGroups`.
+3. Once you fill everything what's need in [aws-eks-kip-provider-config](../deploy/manifests/kip/overlays/aws-eks/provider.yaml) you can deploy KIP using kustomize: `kustomize build deploy/manifests/kip/overlays/aws-eks | kubectl apply -f  -`
+
+Once KIP statefulset pods are running, you should see kip-provider virtual nodes listed as Ready `kubectl get nodes -o wide -l type=virtual-kubelet`.
+

--- a/scripts/eks-smoke-test/kip-nginx.yaml
+++ b/scripts/eks-smoke-test/kip-nginx.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: regular-nginx
+  namespace: kip-smoke-tests
+  labels:
+    app: regular-nginx
+spec:
+  nodeSelector:
+    type: virtual-kubelet
+    kubernetes.io/hostname: kip-provider-0
+  tolerations:
+    - key: usage
+    - value: kip-smoke-tests
+    - effect: NoSchedule
+  containers:
+    - name: nginx
+      image: nginx
+      ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: regular-nginx
+  namespace: kip-smoke-tests
+spec:
+  selector:
+    app: regular-nginx
+  ports:
+    - port: 80
+      targetPort: 80

--- a/scripts/eks-smoke-test/kip-nginx.yaml
+++ b/scripts/eks-smoke-test/kip-nginx.yaml
@@ -11,8 +11,8 @@ spec:
     kubernetes.io/hostname: kip-provider-0
   tolerations:
     - key: usage
-    - value: kip-smoke-tests
-    - effect: NoSchedule
+      value: kip-smoke-tests
+      effect: NoSchedule
   containers:
     - name: nginx
       image: nginx

--- a/scripts/eks-smoke-test/kip-nginx.yaml
+++ b/scripts/eks-smoke-test/kip-nginx.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: regular-nginx
+  name: kip-nginx
   namespace: kip-smoke-tests
   labels:
-    app: regular-nginx
+    app: kip-nginx
 spec:
   nodeSelector:
     type: virtual-kubelet
@@ -22,11 +22,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: regular-nginx
+  name: kip-nginx
   namespace: kip-smoke-tests
 spec:
   selector:
-    app: regular-nginx
+    app: kip-nginx
   ports:
     - port: 80
       targetPort: 80

--- a/scripts/eks-smoke-test/regular-node-nginx.yaml
+++ b/scripts/eks-smoke-test/regular-node-nginx.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: regular-nginx
+  namespace: kip-smoke-tests
+  labels:
+    app: regular-nginx
+spec:
+  nodeSelector:
+    nodeType: regular
+  containers:
+    - name: nginx
+      image: nginx
+      ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: regular-nginx
+  namespace: kip-smoke-tests
+spec:
+  selector:
+    app: regular-nginx
+  ports:
+    - port: 80
+      targetPort: 80

--- a/scripts/run_eks_smoke_test.sh
+++ b/scripts/run_eks_smoke_test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+BUILD=${TRAVIS_BUILD_NUMBER:-local}
+USE_REGION=${USE_REGION:-us-east-1}
+
+handle_error() {
+    trap - EXIT
+    show_kube_info || true
+    cleanup || true
+}
+
+cleanup() {
+    delete_kube_resources
+}
+
+delete_kube_resources() {
+    kubectl delete -f $SCRIPT_DIR/eks-smoke-test/kip-nginx.yaml
+    kubectl delete -f $SCRIPT_DIR/eks-smoke-test/regular-node-nginx.yaml
+    kubectl delete pod test
+}
+
+show_kube_info() {
+    kubectl get pods -A
+    kubectl get nodes
+    kubectl -n kip-smoke-tests describe pod -l statefulset.kubernetes.io/pod-name=kip-build-kip-provider-0
+    kubectl logs -n kip-smoke-tests -l statefulset.kubernetes.io/pod-name=kip-build-kip-provider-0r -c init-cert --tail=-1
+    kubectl logs -n kip-smoke-tests -l statefulset.kubernetes.io/pod-name=kip-build-kip-provider-0 -c kip --tail=-1
+}
+
+update_vk() {
+    local version="$(git describe)"
+    local patch_init="{\"spec\":{\"template\":{\"spec\":{\"initContainers\":[{\"image\":\"elotl/init-cert:$version\",\"name\":\"init-cert\"}]}}}}"
+    local patch_kip="{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"image\":\"elotl/kip:$version\",\"name\":\"kip\"}]}}}}"
+    kubectl patch -n kip-smoke-tests statefulset kip-build-kip-provider -p "$patch_init"
+    kubectl patch -n kip-smoke-tests statefulset kip-build-kip-provider -p "$patch_kip"
+}
+
+run_smoke_test_1() {
+     kubectl apply -f $SCRIPT_DIR/eks-smoke-test/kip-nginx.yaml
+     kubectl apply -f $SCRIPT_DIR/eks-smoke-test/regular-node-nginx.yaml
+     kubectl get nodes -o wide
+     kubectl get pods -n kip-smoke-tests
+#    local curlcmd="i=0; while [ \$i -lt 300 ]; do i=\$((i+1)); curl nginx | grep 'Welcome to nginx' && exit 0; sleep 1; done; exit 1"
+#    local waitcmd="phase=\"\"; echo \"Waiting for test results from pod\"; until [[ \$phase = Succeeded ]]; do sleep 1; phase=\$(kubectl get pod test -ojsonpath=\"{.status.phase}\"); if [[ \$phase = Failed ]]; then echo \$phase; kubectl get pods -A; exit 1; fi; echo \$phase; done"
+#    kubectl run test --restart=Never --image=elotl/debug --command -- /bin/sh -c "$curlcmd"
+#    timeout 420s bash -c "$waitcmd"
+}
+
+run_smoke_test_2() {
+    local curlcmd="i=0; while [ \$i -lt 300 ]; do i=\$((i+1)); curl nginx | grep 'Welcome to nginx' && exit 0; sleep 1; done; exit 1"
+    local waitcmd="phase=\"\"; echo \"Waiting for test results from pod\"; until [[ \$phase = Succeeded ]]; do sleep 1; phase=\$(kubectl get pod test -ojsonpath=\"{.status.phase}\"); if [[ \$phase = Failed ]]; then echo \$phase; kubectl get pods -A; exit 1; fi; echo \$phase; done"
+    kubectl run test --restart=Never --image=elotl/debug --command -- /bin/sh -c "$curlcmd"
+    timeout 420s bash -c "$waitcmd"
+}
+
+fetch_kubeconfig() {
+    echo "fetch kubeconfig"
+    aws eks update-kubeconfig --name elotl-ci-cd
+}
+
+test_once() {
+    set -euxo pipefail
+    trap handle_error EXIT
+    fetch_kubeconfig
+    update_vk
+    run_smoke_test_1
+#    run_smoke_test_2
+    cleanup
+    trap - EXIT
+}
+
+# Run test_once() if running as a shell script, and return if sourced.
+(return 0 2>/dev/null) || test_once

--- a/scripts/run_eks_smoke_test.sh
+++ b/scripts/run_eks_smoke_test.sh
@@ -45,13 +45,15 @@ run_smoke_test_1() {
     local waitcmd="phase=\"\"; echo \"Waiting for test results from pod\"; until [[ \$phase = Succeeded ]]; do sleep 1; phase=\$(kubectl get pod -n kip-smoke-tests test -ojsonpath=\"{.status.phase}\"); if [[ \$phase = Failed ]]; then echo \$phase; kubectl get pods -A; exit 1; fi; echo \$phase; done"
     kubectl run test --restart=Never --namespace=kip-smoke-tests --image=elotl/debug --command -- /bin/sh -c "$curlcmd"
     timeout 420s bash -c "$waitcmd"
+    kubectl delete pod -n kip-smoke-tests test
 }
 
 run_smoke_test_2() {
     local curlcmd="i=0; while [ \$i -lt 300 ]; do i=\$((i+1)); curl kip-nginx.kip-smoke-tests | grep 'Welcome to nginx' && exit 0; sleep 1; done; exit 1"
     local waitcmd="phase=\"\"; echo \"Waiting for test results from pod\"; until [[ \$phase = Succeeded ]]; do sleep 1; phase=\$(kubectl get pod -n kip-smoke-tests test -ojsonpath=\"{.status.phase}\"); if [[ \$phase = Failed ]]; then echo \$phase; kubectl get pods -A; exit 1; fi; echo \$phase; done"
-    kubectl run test --restart=Never --image=elotl/debug --command -- /bin/sh -c "$curlcmd"
+    kubectl run test --restart=Never --namespace=kip-smoke-tests --image=elotl/debug --command -- /bin/sh -c "$curlcmd"
     timeout 420s bash -c "$waitcmd"
+    kubectl delete pod -n kip-smoke-tests test
 }
 
 fetch_kubeconfig() {

--- a/scripts/run_eks_smoke_test.sh
+++ b/scripts/run_eks_smoke_test.sh
@@ -36,7 +36,7 @@ update_vk() {
     local patch_kip="{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"image\":\"elotl/kip:$version\",\"name\":\"kip\"}]}}}}"
 #    kubectl patch -n kip-smoke-tests statefulset kip-build-kip-provider -p "$patch_init"
     kubectl patch -n kip-smoke-tests statefulset kip-build-kip-provider -p "$patch_kip"
-    kubectl taint node kip-build-kip-provider-0 usage=kip-smoke-tests:NoSchedule
+    kubectl taint node kip-build-kip-provider-0 usage=kip-smoke-tests:NoSchedule --overwrite
 }
 
 run_smoke_test_1() {

--- a/scripts/run_eks_smoke_test.sh
+++ b/scripts/run_eks_smoke_test.sh
@@ -58,6 +58,8 @@ run_smoke_test_2() {
 fetch_kubeconfig() {
     echo "fetch kubeconfig"
     aws eks update-kubeconfig --name elotl-ci-cd
+    echo "get user"
+    aws iam get-user # debug
 }
 
 test_once() {

--- a/scripts/run_eks_smoke_test.sh
+++ b/scripts/run_eks_smoke_test.sh
@@ -18,7 +18,8 @@ cleanup() {
 delete_kube_resources() {
     kubectl delete -f $SCRIPT_DIR/eks-smoke-test/kip-nginx.yaml
     kubectl delete -f $SCRIPT_DIR/eks-smoke-test/regular-node-nginx.yaml
-    kubectl delete -n kip-smoke-tests pod test
+    kubectl delete -n kip-smoke-tests pod test --ignore-not-found
+    kubectl delete pod test --ignore-not-found
 }
 
 show_kube_info() {
@@ -39,21 +40,21 @@ update_vk() {
 }
 
 run_smoke_test_1() {
-    kubectl apply -f $SCRIPT_DIR/eks-smoke-test/kip-nginx.yaml
     kubectl apply -f $SCRIPT_DIR/eks-smoke-test/regular-node-nginx.yaml
     local curlcmd="i=0; while [ \$i -lt 300 ]; do i=\$((i+1)); curl regular-nginx.kip-smoke-tests | grep 'Welcome to nginx' && exit 0; sleep 1; done; exit 1"
     local waitcmd="phase=\"\"; echo \"Waiting for test results from pod\"; until [[ \$phase = Succeeded ]]; do sleep 1; phase=\$(kubectl get pod -n kip-smoke-tests test -ojsonpath=\"{.status.phase}\"); if [[ \$phase = Failed ]]; then echo \$phase; kubectl get pods -A; exit 1; fi; echo \$phase; done"
     kubectl run test --restart=Never --namespace=kip-smoke-tests --image=elotl/debug --command -- /bin/sh -c "$curlcmd"
     timeout 420s bash -c "$waitcmd"
-    kubectl delete pod -n kip-smoke-tests test
+    kubectl delete -n kip-smoke-tests pod test --ignore-not-found
 }
 
 run_smoke_test_2() {
+    kubectl apply -f $SCRIPT_DIR/eks-smoke-test/kip-nginx.yaml
     local curlcmd="i=0; while [ \$i -lt 300 ]; do i=\$((i+1)); curl kip-nginx.kip-smoke-tests | grep 'Welcome to nginx' && exit 0; sleep 1; done; exit 1"
     local waitcmd="phase=\"\"; echo \"Waiting for test results from pod\"; until [[ \$phase = Succeeded ]]; do sleep 1; phase=\$(kubectl get pod -n kip-smoke-tests test -ojsonpath=\"{.status.phase}\"); if [[ \$phase = Failed ]]; then echo \$phase; kubectl get pods -A; exit 1; fi; echo \$phase; done"
     kubectl run test --restart=Never --namespace=kip-smoke-tests --image=elotl/debug --command -- /bin/sh -c "$curlcmd"
     timeout 420s bash -c "$waitcmd"
-    kubectl delete pod -n kip-smoke-tests test
+    kubectl delete -n kip-smoke-tests pod test --ignore-not-found
 }
 
 fetch_kubeconfig() {

--- a/scripts/run_eks_smoke_test.sh
+++ b/scripts/run_eks_smoke_test.sh
@@ -18,7 +18,7 @@ cleanup() {
 delete_kube_resources() {
     kubectl delete -f $SCRIPT_DIR/eks-smoke-test/kip-nginx.yaml
     kubectl delete -f $SCRIPT_DIR/eks-smoke-test/regular-node-nginx.yaml
-    kubectl delete -n kube-smoke-tests pod test
+    kubectl delete -n kip-smoke-tests pod test
 }
 
 show_kube_info() {
@@ -31,10 +31,9 @@ show_kube_info() {
 
 update_vk() {
     local version="$(git describe)"
-# TODO: uncomment
-#    local patch_init="{\"spec\":{\"template\":{\"spec\":{\"initContainers\":[{\"image\":\"elotl/init-cert:$version\",\"name\":\"init-cert\"}]}}}}"
+    local patch_init="{\"spec\":{\"template\":{\"spec\":{\"initContainers\":[{\"image\":\"elotl/init-cert:$version\",\"name\":\"init-cert\"}]}}}}"
     local patch_kip="{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"image\":\"elotl/kip:$version\",\"name\":\"kip\"}]}}}}"
-#    kubectl patch -n kip-smoke-tests statefulset kip-build-kip-provider -p "$patch_init"
+    kubectl patch -n kip-smoke-tests statefulset kip-build-kip-provider -p "$patch_init"
     kubectl patch -n kip-smoke-tests statefulset kip-build-kip-provider -p "$patch_kip"
     kubectl taint node kip-build-kip-provider-0 usage=kip-smoke-tests:NoSchedule --overwrite
 }
@@ -43,14 +42,14 @@ run_smoke_test_1() {
     kubectl apply -f $SCRIPT_DIR/eks-smoke-test/kip-nginx.yaml
     kubectl apply -f $SCRIPT_DIR/eks-smoke-test/regular-node-nginx.yaml
     local curlcmd="i=0; while [ \$i -lt 300 ]; do i=\$((i+1)); curl regular-nginx.kip-smoke-tests | grep 'Welcome to nginx' && exit 0; sleep 1; done; exit 1"
-    local waitcmd="phase=\"\"; echo \"Waiting for test results from pod\"; until [[ \$phase = Succeeded ]]; do sleep 1; phase=\$(kubectl get pod -n kube-smoke-tests test -ojsonpath=\"{.status.phase}\"); if [[ \$phase = Failed ]]; then echo \$phase; kubectl get pods -A; exit 1; fi; echo \$phase; done"
+    local waitcmd="phase=\"\"; echo \"Waiting for test results from pod\"; until [[ \$phase = Succeeded ]]; do sleep 1; phase=\$(kubectl get pod -n kip-smoke-tests test -ojsonpath=\"{.status.phase}\"); if [[ \$phase = Failed ]]; then echo \$phase; kubectl get pods -A; exit 1; fi; echo \$phase; done"
     kubectl run test --restart=Never --namespace=kip-smoke-tests --image=elotl/debug --command -- /bin/sh -c "$curlcmd"
     timeout 420s bash -c "$waitcmd"
 }
 
 run_smoke_test_2() {
     local curlcmd="i=0; while [ \$i -lt 300 ]; do i=\$((i+1)); curl kip-nginx.kip-smoke-tests | grep 'Welcome to nginx' && exit 0; sleep 1; done; exit 1"
-    local waitcmd="phase=\"\"; echo \"Waiting for test results from pod\"; until [[ \$phase = Succeeded ]]; do sleep 1; phase=\$(kubectl get pod -n kube-smoke-tests test -ojsonpath=\"{.status.phase}\"); if [[ \$phase = Failed ]]; then echo \$phase; kubectl get pods -A; exit 1; fi; echo \$phase; done"
+    local waitcmd="phase=\"\"; echo \"Waiting for test results from pod\"; until [[ \$phase = Succeeded ]]; do sleep 1; phase=\$(kubectl get pod -n kip-smoke-tests test -ojsonpath=\"{.status.phase}\"); if [[ \$phase = Failed ]]; then echo \$phase; kubectl get pods -A; exit 1; fi; echo \$phase; done"
     kubectl run test --restart=Never --image=elotl/debug --command -- /bin/sh -c "$curlcmd"
     timeout 420s bash -c "$waitcmd"
 }
@@ -58,8 +57,6 @@ run_smoke_test_2() {
 fetch_kubeconfig() {
     echo "fetch kubeconfig"
     aws eks update-kubeconfig --name elotl-ci-cd
-    echo "get user"
-    aws iam get-user # debug
 }
 
 test_once() {


### PR DESCRIPTION
EKS smoke tests scenario:
1. They run in our EKS elotl-ci-cd cluster.
2. We deploy newly built kip version there to `kip-smoke-tests` namespace and we taint a node, so only build jobs can run on it.
3. We deploy two nginx pods: one running on KIP, one on regular node.
4. We deploy another pod which curls those two.
5. If we get expected response, tests are complete.
Those test are meant to check if:
1. Kip starts in EKS cluster
2. KIP pods start successfully.
3. Connectivity between regular <-> kip and kip <-> kip pods

Added also a README with instructions for configuring EKS cluster for KIP.

If we keep `elotl-ci-cd` on Kubernetes version which is currently default for EKS, we can be sure that we support at least current default EKS version.